### PR TITLE
feat: BlockWatcher

### DIFF
--- a/src/adapters/block_fetcher/fuel_block_fetcher.rs
+++ b/src/adapters/block_fetcher/fuel_block_fetcher.rs
@@ -21,7 +21,7 @@ pub struct FuelBlockFetcher {
 
 impl FuelBlockFetcher {
     pub fn new(url: &Url, unhealthy_after_n_errors: usize) -> Self {
-        let client = FuelClient::new(url.to_string()).expect("Url to be well formed");
+        let client = FuelClient::new(url).expect("Url to be well formed");
         let provider = Provider::new(client, Default::default());
         Self {
             provider,

--- a/src/adapters/storage.rs
+++ b/src/adapters/storage.rs
@@ -65,9 +65,8 @@ impl Storage for InMemoryStorage {
             .lock()
             .unwrap()
             .iter()
-            .max_by_key(|(k, _)| k.clone())
-            .map(|(_, v)| v.clone())
-            .clone();
+            .max_by_key(|(k, _)| *k)
+            .map(|(_, v)| v.clone());
         Ok(res)
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -20,7 +20,7 @@ pub async fn launch_api_server(
     fuel_health_check: HealthChecker,
 ) -> Result<()> {
     let metrics_registry = Arc::new(metrics_registry);
-    let status_reporter = Arc::new(StatusReporter::new(storage.clone()));
+    let status_reporter = Arc::new(StatusReporter::new(storage));
     let health_reporter = Arc::new(HealthReporter::new(fuel_health_check));
     HttpServer::new(move || {
         App::new()
@@ -64,7 +64,7 @@ async fn metrics(registry: web::Data<Arc<Registry>>) -> impl Responder {
     let mut buf: Vec<u8> = vec![];
     let mut encode = |metrics: &_| {
         encoder
-            .encode(&metrics, &mut buf)
+            .encode(metrics, &mut buf)
             .map_err(map_to_internal_err)
     };
 

--- a/src/setup/helpers.rs
+++ b/src/setup/helpers.rs
@@ -69,12 +69,8 @@ fn create_block_watcher(
     storage: InMemoryStorage,
 ) -> (BlockWatcher, Receiver<FuelBlock>) {
     let (tx_fuel_block, rx_fuel_block) = tokio::sync::mpsc::channel(100);
-    let block_watcher = BlockWatcher::new(
-        config.commit_epoch,
-        tx_fuel_block,
-        block_fetcher,
-        storage.clone(),
-    );
+    let block_watcher =
+        BlockWatcher::new(config.commit_epoch, tx_fuel_block, block_fetcher, storage);
     block_watcher.register_metrics(registry);
 
     (block_watcher, rx_fuel_block)


### PR DESCRIPTION
closes: #9 
closes: #3 
closes: #6 

Implemented a component that polls for the latest fuel block. Upon receiving it determines whether it should be propagated further and, if so, will proceed to send the update to the Ethereum committer (coming soon).

CLI, metrics, the status check endpoint, and logging were also added.

The test names should be descriptive enough to answer any questions you might have about behavior details.

P.S.
Work done in [this PR](https://github.com/FuelLabs/fuel-block-committer/pull/7) is incorporated here, @MujkicA can you close it when you can?

Work done in [this PR](https://github.com/FuelLabs/fuel-block-committer/pull/6) is also incorporated. @Salka1988 can you close it when you can?