### PR TITLE
ci: enable e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/e2e_test
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
closes: #17 

It would seem it is enough just to run the e2e tests in the CI.

When trying to make this change in the previous PR the CI would inexplicably fail. Couldn't replicate after the PR was merged.