### PR TITLE
feat: periodic wallet balance check

### DIFF
--- a/src/adapters/ethereum_adapter.rs
+++ b/src/adapters/ethereum_adapter.rs
@@ -4,7 +4,7 @@ mod websocket;
 use std::pin::Pin;
 
 use async_trait::async_trait;
-use ethers::types::U256;
+use ethers::types::{H160, U256};
 use futures::Stream;
 pub use monitored_adapter::MonitoredEthAdapter;
 pub use websocket::EthereumWs;
@@ -30,5 +30,6 @@ pub trait EventStreamer {
 pub trait EthereumAdapter: Send + Sync {
     async fn submit(&self, block: FuelBlock) -> Result<()>;
     async fn get_block_number(&self) -> Result<u64>;
+    async fn balance(&self, address: H160) -> Result<U256>;
     fn event_streamer(&self, eth_block_height: u64) -> Box<dyn EventStreamer + Send + Sync>;
 }

--- a/src/adapters/ethereum_adapter/monitored_adapter.rs
+++ b/src/adapters/ethereum_adapter/monitored_adapter.rs
@@ -1,3 +1,4 @@
+use ethers::types::{H160, U256};
 use prometheus::{IntCounter, Opts};
 
 use crate::{
@@ -66,6 +67,12 @@ impl<T: EthereumAdapter> EthereumAdapter for MonitoredEthAdapter<T> {
 
     fn event_streamer(&self, eth_block_height: u64) -> Box<dyn EventStreamer + Send + Sync> {
         self.adapter.event_streamer(eth_block_height)
+    }
+
+    async fn balance(&self, address: H160) -> Result<U256> {
+        let response = self.adapter.balance(address).await;
+        self.note_network_status(&response);
+        response
     }
 }
 

--- a/src/adapters/ethereum_adapter/websocket/adapter.rs
+++ b/src/adapters/ethereum_adapter/websocket/adapter.rs
@@ -49,7 +49,6 @@ impl EthereumWs {
             .map_err(|e| Error::NetworkError(e.to_string()))?;
 
         let wallet = LocalWallet::from_str(ethereum_wallet_key)?.with_chain_id(chain_id);
-        let _wallet_address = wallet.address();
 
         let signer = SignerMiddleware::new(provider.clone(), wallet);
 

--- a/src/adapters/ethereum_adapter/websocket/adapter.rs
+++ b/src/adapters/ethereum_adapter/websocket/adapter.rs
@@ -5,9 +5,8 @@ use ethers::{
     prelude::{abigen, ContractError, SignerMiddleware},
     providers::{Middleware, Provider, Ws},
     signers::{LocalWallet, Signer},
-    types::{Address, Chain, U256, U64},
+    types::{Address, Chain, H160, U256, U64},
 };
-use prometheus::{IntGauge, Opts};
 use serde_json::Value;
 use tracing::info;
 use url::Url;
@@ -20,7 +19,6 @@ use crate::{
         },
     },
     errors::{Error, Result},
-    telemetry::RegistersMetrics,
 };
 
 abigen!(
@@ -35,9 +33,7 @@ abigen!(
 pub struct EthereumWs {
     provider: Provider<Ws>,
     contract: FUEL_STATE_CONTRACT<SignerMiddleware<Provider<Ws>, LocalWallet>>,
-    wallet_address: Address,
     commit_interval: NonZeroU32,
-    metrics: Metrics,
 }
 
 impl EthereumWs {
@@ -53,7 +49,7 @@ impl EthereumWs {
             .map_err(|e| Error::NetworkError(e.to_string()))?;
 
         let wallet = LocalWallet::from_str(ethereum_wallet_key)?.with_chain_id(chain_id);
-        let wallet_address = wallet.address();
+        let _wallet_address = wallet.address();
 
         let signer = SignerMiddleware::new(provider.clone(), wallet);
 
@@ -63,38 +59,12 @@ impl EthereumWs {
         Ok(Self {
             provider,
             contract,
-            wallet_address,
             commit_interval,
-            metrics: Default::default(),
         })
-    }
-
-    async fn record_balance(&self) -> Result<()> {
-        let balance = self
-            .provider
-            .get_balance(self.wallet_address, None)
-            .await
-            .map_err(|err| Error::NetworkError(err.to_string()))?;
-
-        info!("wallet balance: {}", &balance);
-
-        // Note: might lead to wrong metrics if we have more than 500k ETH
-        let balance_gwei = balance / U256::from(1_000_000_000);
-        self.metrics
-            .eth_wallet_balance
-            .set(balance_gwei.as_u64() as i64);
-
-        Ok(())
     }
 
     fn calculate_commit_height(block_height: u32, commit_interval: NonZeroU32) -> U256 {
         (block_height / commit_interval).into()
-    }
-}
-
-impl RegistersMetrics for EthereumWs {
-    fn metrics(&self) -> Vec<Box<dyn prometheus::core::Collector>> {
-        self.metrics.metrics()
     }
 }
 
@@ -113,8 +83,6 @@ impl EthereumAdapter for EthereumWs {
             })?;
 
         info!("tx: {} submitted", tx.tx_hash());
-
-        self.record_balance().await?;
 
         Ok(())
     }
@@ -139,28 +107,12 @@ impl EthereumAdapter for EthereumWs {
 
         Box::new(EthEventStreamer::new(events))
     }
-}
 
-#[derive(Clone)]
-struct Metrics {
-    eth_wallet_balance: IntGauge,
-}
-
-impl RegistersMetrics for Metrics {
-    fn metrics(&self) -> Vec<Box<dyn prometheus::core::Collector>> {
-        vec![Box::new(self.eth_wallet_balance.clone())]
-    }
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        let eth_wallet_balance = IntGauge::with_opts(Opts::new(
-            "eth_wallet_balance",
-            "Ethereum wallet balance [gwei].",
-        ))
-        .expect("eth_wallet_balance metric to be correctly configured");
-
-        Self { eth_wallet_balance }
+    async fn balance(&self, address: H160) -> Result<U256> {
+        self.provider
+            .get_balance(address, None)
+            .await
+            .map_err(|err| Error::NetworkError(err.to_string()))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use setup::{
     config::InternalConfig,
     helpers::{
         create_eth_adapter, setup_logger, setup_storage, spawn_block_watcher,
-        spawn_eth_committer_and_listener,
+        spawn_eth_committer_and_listener, spawn_wallet_balance_tracker,
     },
 };
 
@@ -37,6 +37,13 @@ async fn main() -> Result<()> {
 
     let (ethereum_rpc, eth_health_check) =
         create_eth_adapter(&config, &internal_config, &metrics_registry).await?;
+
+    let _wallet_balance_tracker_handle = spawn_wallet_balance_tracker(
+        &config,
+        &internal_config,
+        &metrics_registry,
+        ethereum_rpc.clone(),
+    )?;
 
     let (_committer_handle, _listener_handle) = spawn_eth_committer_and_listener(
         &internal_config,

--- a/src/services.rs
+++ b/src/services.rs
@@ -3,9 +3,11 @@ mod block_watcher;
 mod commit_listener;
 mod health_reporter;
 mod status_reporter;
+mod wallet_balance_tracker;
 
 pub use block_committer::BlockCommitter;
 pub use block_watcher::BlockWatcher;
 pub use commit_listener::CommitListener;
 pub use health_reporter::HealthReporter;
 pub use status_reporter::{Status, StatusReporter};
+pub use wallet_balance_tracker::WalletBalanceTracker;

--- a/src/services/wallet_balance_tracker.rs
+++ b/src/services/wallet_balance_tracker.rs
@@ -1,0 +1,129 @@
+use std::str::FromStr;
+
+use ethers::{
+    signers::{LocalWallet, Signer},
+    types::{H160, U256},
+};
+use prometheus::{IntGauge, Opts};
+
+use crate::{
+    adapters::{ethereum_adapter::EthereumAdapter, runner::Runner},
+    errors::Result,
+    telemetry::RegistersMetrics,
+};
+
+pub struct WalletBalanceTracker {
+    eth_adapter: Box<dyn EthereumAdapter>,
+    metrics: Metrics,
+    address: H160,
+}
+
+impl WalletBalanceTracker {
+    pub fn new(adapter: impl EthereumAdapter + 'static, ethereum_wallet_key: &str) -> Self {
+        let address = LocalWallet::from_str(ethereum_wallet_key)
+            .expect("Valid eth key")
+            .address();
+        Self {
+            eth_adapter: Box::new(adapter),
+            metrics: Metrics::default(),
+            address,
+        }
+    }
+
+    pub async fn update_balance(&self) -> Result<()> {
+        let balance = self.eth_adapter.balance(self.address).await?;
+
+        let balance_gwei = balance / U256::from(1_000_000_000);
+        self.metrics
+            .eth_wallet_balance
+            .set(balance_gwei.as_u64() as i64);
+
+        Ok(())
+    }
+}
+
+impl RegistersMetrics for WalletBalanceTracker {
+    fn metrics(&self) -> Vec<Box<dyn prometheus::core::Collector>> {
+        self.metrics.metrics()
+    }
+}
+
+#[derive(Clone)]
+struct Metrics {
+    eth_wallet_balance: IntGauge,
+}
+
+impl RegistersMetrics for Metrics {
+    fn metrics(&self) -> Vec<Box<dyn prometheus::core::Collector>> {
+        vec![Box::new(self.eth_wallet_balance.clone())]
+    }
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        let eth_wallet_balance = IntGauge::with_opts(Opts::new(
+            "eth_wallet_balance",
+            "Ethereum wallet balance [gwei].",
+        ))
+        .expect("eth_wallet_balance metric to be correctly configured");
+
+        Self { eth_wallet_balance }
+    }
+}
+
+#[async_trait::async_trait]
+impl Runner for WalletBalanceTracker {
+    async fn run(&mut self) -> Result<()> {
+        self.update_balance().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::predicate::eq;
+    use prometheus::Registry;
+
+    use super::*;
+    use crate::adapters::ethereum_adapter::MockEthereumAdapter;
+
+    #[tokio::test]
+    async fn updates_metrics() {
+        // given
+        let eth_private_key = "0000000000000000000000000000000000000000000000000000000000000001";
+        let eth_adapter = given_eth_adapter(
+            "500000000000000000000",
+            "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+        );
+        let registry = Registry::new();
+
+        let sut = WalletBalanceTracker::new(eth_adapter, eth_private_key);
+        sut.register_metrics(&registry);
+
+        // when
+        sut.update_balance().await.unwrap();
+
+        // then
+        let metrics = registry.gather();
+        let latest_block_metric = metrics
+            .iter()
+            .find(|metric| metric.get_name() == "eth_wallet_balance")
+            .and_then(|metric| metric.get_metric().get(0))
+            .map(|metric| metric.get_gauge())
+            .unwrap();
+
+        assert_eq!(latest_block_metric.get_value(), 500000000000f64);
+    }
+
+    fn given_eth_adapter(wei_balance: &str, expected_addr: &str) -> MockEthereumAdapter {
+        let addr = H160::from_str(expected_addr).unwrap();
+        let balance = U256::from_dec_str(wei_balance).unwrap();
+
+        let mut eth_adapter = MockEthereumAdapter::new();
+        eth_adapter
+            .expect_balance()
+            .with(eq(addr))
+            .return_once(move |_| Ok(balance));
+
+        eth_adapter
+    }
+}

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -22,6 +22,7 @@ pub struct InternalConfig {
     pub fuel_errors_before_unhealthy: usize,
     pub between_eth_event_stream_restablishing_attempts: Duration,
     pub eth_errors_before_unhealthy: usize,
+    pub balance_update_interval: Duration,
 }
 
 impl Default for InternalConfig {
@@ -31,6 +32,7 @@ impl Default for InternalConfig {
             fuel_errors_before_unhealthy: 3,
             between_eth_event_stream_restablishing_attempts: Duration::from_secs(3),
             eth_errors_before_unhealthy: 3,
+            balance_update_interval: Duration::from_secs(10),
         }
     }
 }


### PR DESCRIPTION
closes: #19 
Wallet balance will now be checked every 10s. 

Besides giving a better insight into the balance it also serves as a good heartbeat for the Ethereum connection since it will reuse the same provider over which we commit blocks.

As things currently stand, if our connection is unhealthy for 30s the service will become unhealthy.