### PR TITLE
cancel previous jobs on new commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUST_VERSION: 1.70.0


### PR DESCRIPTION
noticed that we had several concurrent long-running jobs clogging up the runners when multiple commits were pushed to the same branch, this concurrency limit should fit that.