### PR TITLE
chore: bump fuel-core version to use the latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUST_VERSION: 1.73.0
-  FUEL_CORE_VERSION: 0.21.0-rc.1
+  FUEL_CORE_VERSION: 0.21.0
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
-  RUST_VERSION: 1.73.0
-  FUEL_CORE_VERSION: 0.21.0
+  RUST_VERSION: 1.74.0
+  FUEL_CORE_VERSION: 0.22.0
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
-  RUST_VERSION: 1.70.0
-  FUEL_CORE_VERSION: 0.20.4
+  RUST_VERSION: 1.73.0
+  FUEL_CORE_VERSION: 0.21.0-rc.1
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/harness.rs"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.68"
-fuel-core-client = "0.21.0"
+fuel-core-client = "0.22.0"
 prometheus = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 ethers = { version = "2.0", features = ["ws"] }
@@ -32,8 +32,7 @@ rusqlite = { version = "0.30", features = ["bundled"] }
 futures = "0.3.28"
 
 [dev-dependencies]
-#Disabled until the SDK gets a non RC version of fuel-core deps
-#fuels-test-helpers = "0.51.0"
+fuels-test-helpers = "0.54.0"
 rand = "0.8.5"
 mockall = "0.11.4"
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-block-committer"
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 version = "0.1.0"
 name = "fuel-block-committer"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-block-committer"
-rust-version = "1.73.0"
+rust-version = "1.74.0"
 version = "0.1.0"
 name = "fuel-block-committer"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/harness.rs"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.68"
-fuel-core-client = "0.20.4"
+fuel-core-client = "0.21.0-rc.1"
 prometheus = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 ethers = { version = "2.0", features = ["ws"] }
@@ -25,14 +25,15 @@ tokio-util = { version = "0.7.8" }
 thiserror = "1.0.40"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json"] }
-clap = { version ="4.3", features =["derive", "env"] }
+clap = { version = "4.3", features = ["derive", "env"] }
 url = "2.3"
 serde_json = "1.0.96"
-rusqlite = { version = "0.29", features = ["bundled"] }
+rusqlite = { version = "0.30", features = ["bundled"] }
 futures = "0.3.28"
 
 [dev-dependencies]
-fuels-test-helpers="0.45.1"
+#Disabled until the SDK gets a non RC version of fuel-core deps
+#fuels-test-helpers = "0.51.0"
 rand = "0.8.5"
 mockall = "0.11.4"
 anyhow = "1.0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/harness.rs"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.68"
-fuel-core-client = "0.21.0-rc.1"
+fuel-core-client = "0.21.0"
 prometheus = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 ethers = { version = "2.0", features = ["ws"] }

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.21.0}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.22.0}"
     container_name: fuel-node
     environment:
       - PORT=4000

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,14 +17,14 @@ services:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.20.4}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.21.0-rc.1}"
     container_name: fuel-node
     environment:
       - PORT=4000
       - IP=0.0.0.0
       - DATABASE_TYPE=in-memory
-      - MANUAL_BLOCKS_ENABLED=true
       - INSTANT=true
+      - DEBUG=true
       # - PERIOD=6s
     ports:
       - "4000:4000"

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,7 @@ services:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.21.0-rc.1}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.21.0}"
     container_name: fuel-node
     environment:
       - PORT=4000

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.73 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.74 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.70 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.73 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 

--- a/eth_node/Dockerfile
+++ b/eth_node/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18 AS fetcher
 RUN apk add --no-cache git 
 RUN git clone --no-checkout https://github.com/FuelLabs/fuel-v2-contracts
-RUN cd fuel-v2-contracts && git checkout a83444964db35cc1b93ee7a81d5f47d771083966
+RUN cd fuel-v2-contracts && git checkout 81b35368764e6f83969e502812e14baa30b20f95
 RUN sed 's/\(BLOCKS_PER_COMMIT_INTERVAL\) = 10800/\1 = 3/g' -i fuel-v2-contracts/contracts/fuelchain/FuelChainState.sol
 RUN sed 's/\(TIME_TO_FINALIZE\) = 10800/\1 = 1/g' -i fuel-v2-contracts/contracts/fuelchain/FuelChainState.sol
 

--- a/src/adapters/ethereum_adapter/websocket/adapter.rs
+++ b/src/adapters/ethereum_adapter/websocket/adapter.rs
@@ -46,7 +46,7 @@ impl EthereumWs {
     ) -> Result<Self> {
         let provider = Provider::<Ws>::connect(ethereum_rpc.to_string())
             .await
-            .map_err(|e| Error::NetworkError(e.to_string()))?;
+            .map_err(|e| Error::Network(e.to_string()))?;
 
         let wallet = LocalWallet::from_str(ethereum_wallet_key)?.with_chain_id(chain_id);
 
@@ -76,8 +76,8 @@ impl EthereumAdapter for EthereumWs {
             .send()
             .await
             .map_err(|contract_err| match contract_err {
-                ContractError::ProviderError { e } => Error::NetworkError(e.to_string()),
-                ContractError::MiddlewareError { e } => Error::NetworkError(e.to_string()),
+                ContractError::ProviderError { e } => Error::Network(e.to_string()),
+                ContractError::MiddlewareError { e } => Error::Network(e.to_string()),
                 _ => Error::Other(contract_err.to_string()),
             })?;
 
@@ -94,7 +94,7 @@ impl EthereumAdapter for EthereumWs {
         self.provider
             .request("eth_blockNumber", Value::Array(vec![]))
             .await
-            .map_err(|err| Error::NetworkError(err.to_string()))
+            .map_err(|err| Error::Network(err.to_string()))
             .map(|height: U64| height.as_u64())
     }
 
@@ -111,7 +111,7 @@ impl EthereumAdapter for EthereumWs {
         self.provider
             .get_balance(address, None)
             .await
-            .map_err(|err| Error::NetworkError(err.to_string()))
+            .map_err(|err| Error::Network(err.to_string()))
     }
 }
 

--- a/src/adapters/ethereum_adapter/websocket/event_streamer.rs
+++ b/src/adapters/ethereum_adapter/websocket/event_streamer.rs
@@ -33,7 +33,7 @@ impl EventStreamer for EthEventStreamer {
             self.events
                 .subscribe()
                 .await
-                .map_err(|e| Error::NetworkError(e.to_string()))?
+                .map_err(|e| Error::Network(e.to_string()))?
                 .map_ok(|event| {
                     let fuel_block_hash = event.block_hash;
                     let commit_height = event.commit_height;

--- a/src/adapters/fuel_adapter/fuel_client.rs
+++ b/src/adapters/fuel_adapter/fuel_client.rs
@@ -80,59 +80,62 @@ impl FuelAdapter for FuelClient {
 
 #[cfg(test)]
 mod tests {
+    use fuels_test_helpers::{setup_test_provider, Config};
     use prometheus::{proto::Metric, Registry};
 
     use super::*;
 
-    // TODO: Disabled until the SDK is updated with a non rc version of fuel-core. Conflict between
-    // versions of fuel-types used.
-    // #[tokio::test]
-    // async fn can_fetch_latest_block() {
-    //     // given
-    //     let node_config = Config {
-    //         manual_blocks_enabled: true,
-    //         ..Config::local_node()
-    //     };
-    //
-    //     let (provider, addr) =
-    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
-    //     provider.produce_blocks(5, None).await.unwrap();
-    //
-    //     let url = Url::parse(&format!("http://{addr}")).unwrap();
-    //
-    //     let fuel_adapter = FuelClient::new(&url, 1);
-    //
-    //     // when
-    //     let result = fuel_adapter.latest_block().await.unwrap();
-    //
-    //     // then
-    //     assert_eq!(result.height, 5);
-    // }
+    #[tokio::test]
+    async fn can_fetch_latest_block() {
+        // given
+        let node_config = Config {
+            debug: true,
+            ..Default::default()
+        };
 
-    // TODO: Disabled until the SDK is updated with a non rc version of fuel-core. Conflict between
-    // versions of fuel-types used.
-    // #[tokio::test]
-    // async fn can_fetch_block_at_height() {
-    //     // given
-    //     let node_config = Config {
-    //         manual_blocks_enabled: true,
-    //         ..Config::local_node()
-    //     };
-    //
-    //     let (provider, addr) =
-    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
-    //     provider.produce_blocks(5, None).await.unwrap();
-    //
-    //     let url = Url::parse(&format!("http://{addr}")).unwrap();
-    //
-    //     let fuel_adapter = FuelClient::new(&url, 1);
-    //
-    //     // when
-    //     let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
-    //
-    //     // then
-    //     assert_eq!(result.height, 3);
-    // }
+        let provider =
+            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
+                .await
+                .unwrap();
+        provider.produce_blocks(5, None).await.unwrap();
+
+        let addr = provider.url();
+        let url = Url::parse(addr).unwrap();
+        dbg!(&url);
+
+        let fuel_adapter = FuelClient::new(&url, 1);
+
+        // when
+        let result = fuel_adapter.latest_block().await.unwrap();
+
+        // then
+        assert_eq!(result.height, 5);
+    }
+
+    #[tokio::test]
+    async fn can_fetch_block_at_height() {
+        // given
+        let node_config = Config {
+            debug: true,
+            ..Default::default()
+        };
+
+        let provider =
+            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
+                .await
+                .unwrap();
+        provider.produce_blocks(5, None).await.unwrap();
+
+        let url = Url::parse(provider.url()).unwrap();
+
+        let fuel_adapter = FuelClient::new(&url, 1);
+
+        // when
+        let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
+
+        // then
+        assert_eq!(result.height, 3);
+    }
 
     #[tokio::test]
     async fn updates_metrics_in_case_of_network_err() {

--- a/src/adapters/fuel_adapter/fuel_client.rs
+++ b/src/adapters/fuel_adapter/fuel_client.rs
@@ -45,7 +45,7 @@ impl FuelClient {
 
 impl From<FuelGqlBlock> for FuelBlock {
     fn from(value: FuelGqlBlock) -> Self {
-        FuelBlock {
+        Self {
             hash: *value.id,
             height: value.header.height,
         }
@@ -57,9 +57,9 @@ impl FuelAdapter for FuelClient {
     async fn block_at_height(&self, height: u32) -> Result<Option<FuelBlock>> {
         let maybe_block = self
             .client
-            .block_by_height(height as u64)
+            .block_by_height(height)
             .await
-            .map_err(|e| Error::NetworkError(e.to_string()))?;
+            .map_err(|e| Error::Network(e.to_string()))?;
 
         Ok(maybe_block.map(Into::into))
     }
@@ -72,7 +72,7 @@ impl FuelAdapter for FuelClient {
             }
             Err(err) => {
                 self.handle_network_error();
-                Err(Error::NetworkError(err.to_string()))
+                Err(Error::Network(err.to_string()))
             }
         }
     }
@@ -80,56 +80,59 @@ impl FuelAdapter for FuelClient {
 
 #[cfg(test)]
 mod tests {
-    use fuels_test_helpers::{setup_test_provider, Config};
-    use prometheus::Registry;
+    use prometheus::{proto::Metric, Registry};
 
     use super::*;
 
-    #[tokio::test]
-    async fn can_fetch_latest_block() {
-        // given
-        let node_config = Config {
-            manual_blocks_enabled: true,
-            ..Config::local_node()
-        };
+    // TODO: Disabled until the SDK is updated with a non rc version of fuel-core. Conflict between
+    // versions of fuel-types used.
+    // #[tokio::test]
+    // async fn can_fetch_latest_block() {
+    //     // given
+    //     let node_config = Config {
+    //         manual_blocks_enabled: true,
+    //         ..Config::local_node()
+    //     };
+    //
+    //     let (provider, addr) =
+    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
+    //     provider.produce_blocks(5, None).await.unwrap();
+    //
+    //     let url = Url::parse(&format!("http://{addr}")).unwrap();
+    //
+    //     let fuel_adapter = FuelClient::new(&url, 1);
+    //
+    //     // when
+    //     let result = fuel_adapter.latest_block().await.unwrap();
+    //
+    //     // then
+    //     assert_eq!(result.height, 5);
+    // }
 
-        let (provider, addr) =
-            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
-        provider.produce_blocks(5, None).await.unwrap();
-
-        let url = Url::parse(&format!("http://{addr}")).unwrap();
-
-        let fuel_adapter = FuelClient::new(&url, 1);
-
-        // when
-        let result = fuel_adapter.latest_block().await.unwrap();
-
-        // then
-        assert_eq!(result.height, 5);
-    }
-
-    #[tokio::test]
-    async fn can_fetch_block_at_height() {
-        // given
-        let node_config = Config {
-            manual_blocks_enabled: true,
-            ..Config::local_node()
-        };
-
-        let (provider, addr) =
-            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
-        provider.produce_blocks(5, None).await.unwrap();
-
-        let url = Url::parse(&format!("http://{addr}")).unwrap();
-
-        let fuel_adapter = FuelClient::new(&url, 1);
-
-        // when
-        let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
-
-        // then
-        assert_eq!(result.height, 3);
-    }
+    // TODO: Disabled until the SDK is updated with a non rc version of fuel-core. Conflict between
+    // versions of fuel-types used.
+    // #[tokio::test]
+    // async fn can_fetch_block_at_height() {
+    //     // given
+    //     let node_config = Config {
+    //         manual_blocks_enabled: true,
+    //         ..Config::local_node()
+    //     };
+    //
+    //     let (provider, addr) =
+    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default())).await;
+    //     provider.produce_blocks(5, None).await.unwrap();
+    //
+    //     let url = Url::parse(&format!("http://{addr}")).unwrap();
+    //
+    //     let fuel_adapter = FuelClient::new(&url, 1);
+    //
+    //     // when
+    //     let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
+    //
+    //     // then
+    //     assert_eq!(result.height, 3);
+    // }
 
     #[tokio::test]
     async fn updates_metrics_in_case_of_network_err() {
@@ -151,8 +154,8 @@ mod tests {
         let network_errors_metric = metrics
             .iter()
             .find(|metric| metric.get_name() == "fuel_network_errors")
-            .and_then(|metric| metric.get_metric().get(0))
-            .map(|metric| metric.get_counter())
+            .and_then(|metric| metric.get_metric().first())
+            .map(Metric::get_counter)
             .unwrap();
 
         assert_eq!(network_errors_metric.get_value(), 1f64);

--- a/src/adapters/fuel_adapter/fuel_client.rs
+++ b/src/adapters/fuel_adapter/fuel_client.rs
@@ -101,8 +101,6 @@ mod tests {
 
         let addr = provider.url();
         let url = Url::parse(addr).unwrap();
-        dbg!(&url);
-
         let fuel_adapter = FuelClient::new(&url, 1);
 
         // when

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,20 +8,20 @@ pub enum Error {
     #[error("{0}")]
     Other(String),
     #[error("Network Error: {0}")]
-    NetworkError(String),
+    Network(String),
     #[error("Storage Error: {0}")]
-    StorageError(String),
+    Storage(String),
 }
 
 impl From<rusqlite::Error> for Error {
     fn from(value: rusqlite::Error) -> Self {
-        Self::StorageError(value.to_string())
+        Self::Storage(value.to_string())
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(value: serde_json::Error) -> Self {
-        Self::StorageError(value.to_string())
+        Self::Storage(value.to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<()> {
         &metrics_registry,
         ethereum_rpc.clone(),
         cancel_token.clone(),
-    )?;
+    );
 
     let (committer_handle, listener_handle) = spawn_eth_committer_and_listener(
         &internal_config,
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         storage.clone(),
         &metrics_registry,
         cancel_token.clone(),
-    )?;
+    );
 
     launch_api_server(
         &config,

--- a/src/services.rs
+++ b/src/services.rs
@@ -9,5 +9,5 @@ pub use block_committer::BlockCommitter;
 pub use block_watcher::BlockWatcher;
 pub use commit_listener::CommitListener;
 pub use health_reporter::HealthReporter;
-pub use status_reporter::{Status, StatusReporter};
+pub use status_reporter::StatusReporter;
 pub use wallet_balance_tracker::WalletBalanceTracker;

--- a/src/services/wallet_balance_tracker.rs
+++ b/src/services/wallet_balance_tracker.rs
@@ -81,7 +81,7 @@ impl Runner for WalletBalanceTracker {
 #[cfg(test)]
 mod tests {
     use mockall::predicate::eq;
-    use prometheus::Registry;
+    use prometheus::{proto::Metric, Registry};
 
     use super::*;
     use crate::adapters::ethereum_adapter::MockEthereumAdapter;
@@ -104,14 +104,14 @@ mod tests {
 
         // then
         let metrics = registry.gather();
-        let latest_block_metric = metrics
+        let eth_balance_metric = metrics
             .iter()
             .find(|metric| metric.get_name() == "eth_wallet_balance")
-            .and_then(|metric| metric.get_metric().get(0))
-            .map(|metric| metric.get_gauge())
+            .and_then(|metric| metric.get_metric().first())
+            .map(Metric::get_gauge)
             .unwrap();
 
-        assert_eq!(latest_block_metric.get_value(), 500000000000f64);
+        assert_eq!(eth_balance_metric.get_value(), 500_000_000_000_f64);
     }
 
     fn given_eth_adapter(wei_balance: &str, expected_addr: &str) -> MockEthereumAdapter {

--- a/src/setup/helpers.rs
+++ b/src/setup/helpers.rs
@@ -50,20 +50,18 @@ pub fn spawn_wallet_balance_tracker(
     registry: &Registry,
     ethereum_rpc: MonitoredEthAdapter<EthereumWs>,
     cancel_token: CancellationToken,
-) -> Result<tokio::task::JoinHandle<()>> {
+) -> tokio::task::JoinHandle<()> {
     let wallet_balance_tracker =
         WalletBalanceTracker::new(ethereum_rpc, &config.ethereum_wallet_key);
 
     wallet_balance_tracker.register_metrics(registry);
 
-    let listener_handle = schedule_polling(
+    schedule_polling(
         internal_config.balance_update_interval,
         wallet_balance_tracker,
         "Wallet Balance Tracker",
         cancel_token,
-    );
-
-    Ok(listener_handle)
+    )
 }
 
 pub fn spawn_eth_committer_and_listener(
@@ -73,7 +71,7 @@ pub fn spawn_eth_committer_and_listener(
     storage: SqliteDb,
     registry: &Registry,
     cancel_token: CancellationToken,
-) -> Result<(tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>)> {
+) -> (tokio::task::JoinHandle<()>, tokio::task::JoinHandle<()>) {
     let committer_handler =
         create_block_committer(rx_fuel_block, ethereum_rpc.clone(), storage.clone());
 
@@ -87,7 +85,7 @@ pub fn spawn_eth_committer_and_listener(
         cancel_token,
     );
 
-    Ok((committer_handler, listener_handle))
+    (committer_handler, listener_handle)
 }
 
 fn create_block_committer(
@@ -213,7 +211,7 @@ pub async fn shut_down(
         committer_handle,
         listener_handle,
     ] {
-        handle.await?
+        handle.await?;
     }
 
     Ok(())

--- a/src/telemetry/health_tracker.rs
+++ b/src/telemetry/health_tracker.rs
@@ -32,7 +32,7 @@ impl ConnectionHealthTracker {
     fn acquire_consecutive_failures(&self) -> std::sync::MutexGuard<usize> {
         self.consecutive_failures
             .lock()
-            .expect("no need to handle poisoning since lock duration is short and no panics occurr")
+            .expect("no need to handle poisoning since lock duration is short and no panics occur")
     }
 
     pub fn tracker(&self) -> HealthChecker {


### PR DESCRIPTION
Bumped the version of the fuel core client to the latest version:

```cargo
fuel-core-client = "0.22.0"
```

Also bumped the rust version and the fuel v2 contracts repo used in the e2e tests.