### PR TITLE
chore: update e2e tests to use the contracts from the `fuel-bridge` repo

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,15 +9,19 @@ services:
       interval: 1s
       timeout: 30s
       retries: 50
-    environment:
-      - WALLET_KEY=0x9e56ccf010fa4073274b8177ccaad46fbaf286645310d03ac9bb6afa922a7c36
-      - URL=http://0.0.0.0:8545/
+    command:
+      - "--key"
+      - "0x9e56ccf010fa4073274b8177ccaad46fbaf286645310d03ac9bb6afa922a7c36"
+      - "--ip"
+      - "0.0.0.0"
+      - "--port"
+      - "8545"
 
   fuel_node:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.22.0}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.22.1}"
     container_name: fuel-node
     environment:
       - PORT=4000

--- a/eth_node/Dockerfile
+++ b/eth_node/Dockerfile
@@ -1,19 +1,23 @@
-FROM alpine:3.18 AS fetcher
+FROM alpine:3.19.1 AS fetcher
 RUN apk add --no-cache git 
-RUN git clone --no-checkout https://github.com/FuelLabs/fuel-v2-contracts
-RUN cd fuel-v2-contracts && git checkout 81b35368764e6f83969e502812e14baa30b20f95
-RUN sed 's/\(BLOCKS_PER_COMMIT_INTERVAL\) = 10800/\1 = 3/g' -i fuel-v2-contracts/contracts/fuelchain/FuelChainState.sol
-RUN sed 's/\(TIME_TO_FINALIZE\) = 10800/\1 = 1/g' -i fuel-v2-contracts/contracts/fuelchain/FuelChainState.sol
+RUN git clone --no-checkout https://github.com/FuelLabs/fuel-bridge \
+  && cd fuel-bridge \
+  && git checkout 3587c5c \
+  && cd packages/solidity-contracts \
+  && rm -rf deploy deployments exports test \
+  && cd contracts \
+  && sed 's/\(BLOCKS_PER_COMMIT_INTERVAL\) = 10800/\1 = 3/g' -i ./fuelchain/FuelChainState.sol \
+  && sed 's/\(TIME_TO_FINALIZE\) = 10800/\1 = 1/g' -i ./fuelchain/FuelChainState.sol
 
-FROM alpine:3.18
-RUN apk add --no-cache nodejs npm bash
+FROM alpine:3.19.1
+RUN apk add --no-cache nodejs npm bash curl && npm install -g pnpm
 
-COPY --from=fetcher fuel-v2-contracts /fuel-v2-contracts/
+COPY --from=fetcher fuel-bridge /fuel-bridge
 
-WORKDIR /fuel-v2-contracts
+WORKDIR /fuel-bridge/packages/solidity-contracts
 
-RUN npm install && npm run compile &> /dev/null && npm cache clean --force
+RUN pnpm install && pnpm compile && mkdir deployments
 
 COPY hardhat.config.ts run.sh ./
 
-CMD ["./run.sh"]
+ENTRYPOINT ["./run.sh"]

--- a/eth_node/hardhat.config.ts
+++ b/eth_node/hardhat.config.ts
@@ -1,43 +1,44 @@
-import { HardhatUserConfig } from 'hardhat/types';
-import '@nomiclabs/hardhat-waffle';
-import '@nomiclabs/hardhat-etherscan';
+import type { HardhatUserConfig } from 'hardhat/types';
+import '@nomicfoundation/hardhat-ethers';
+import '@nomicfoundation/hardhat-network-helpers';
+import '@nomicfoundation/hardhat-verify';
+import '@nomicfoundation/hardhat-chai-matchers';
+import '@typechain/hardhat';
 import '@openzeppelin/hardhat-upgrades';
-import 'hardhat-typechain';
+import 'hardhat-deploy';
 import 'solidity-coverage';
-import 'hardhat-gas-reporter';
-import { config as dotEnvConfig } from 'dotenv';
-
-dotEnvConfig();
 
 const config: HardhatUserConfig = {
-    defaultNetwork: 'hardhat',
-    solidity: {
-        compilers: [
-            {
-                version: '0.8.9',
-                settings: {
-                    optimizer: {
-                        enabled: true,
-                        runs: 10000,
-                    },
-                },
-            },
-        ],
-    },
-    networks: {
-        hardhat: {
-            mining: {
-                auto: true,
-                interval: 1000,
-            },
-            accounts: [ { privateKey: "WALLET_KEY", balance: "10000000000000000000000" } ], 
+  defaultNetwork: 'hardhat',
+  solidity: {
+    compilers: [
+      {
+        version: '0.8.9',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 10000,
+          },
         },
-        custom: {
-            accounts: [ "WALLET_KEY" ], 
-            url: "URL",
-            live: true,
+      },
+    ],
+  },
+  networks: {
+    hardhat: {
+        accounts: [ { privateKey: "KEY", balance: "10000000000000000000000" } ],
+        mining: {
+            auto: true,
+            interval: 1000,
         },
     },
+    localhost: {
+        accounts: [ "KEY" ],
+        url: "URL",
+    },
+  },
+  typechain: {
+    outDir: 'typechain',
+  },
 };
 
 export default config;

--- a/eth_node/run.sh
+++ b/eth_node/run.sh
@@ -35,16 +35,14 @@ wait_node_healthy() {
 		exit 1
 	fi
 
-	RETRIES=${RETRIES:-120}
-	JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
 	curl \
 		--fail \
 		--silent \
 		-H "Content-Type: application/json" \
 		--retry-connrefused \
-		--retry "$RETRIES" \
+		--retry 120 \
 		--retry-delay 1 \
-		-d "$JSON" \
+		-d '{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}' \
 		"$URL" >/dev/null
 }
 

--- a/eth_node/run.sh
+++ b/eth_node/run.sh
@@ -19,7 +19,6 @@ replace_placeholders() {
 spawn_eth_node() {
 	IP="$1"
 	PORT="$2"
-	OUT_FILE="$3"
 	if [[ -z "$IP" ]] || [[ -z "$PORT" ]]; then
 		echo "usage: spawn_eth_node <ip> <port>"
 		exit 1

--- a/eth_node/run.sh
+++ b/eth_node/run.sh
@@ -1,29 +1,114 @@
-#!/bin/bash
+#!/bin/sh
+set -e
+PORT="9545"
+IP="0.0.0.0"
 
-for ENV_VAR in WALLET_KEY URL; do
-    if [[ -z "${!ENV_VAR}" ]]; then
-        echo "${ENV_VAR} not set!"
-        exit 1
-    fi
-    sed "s#$ENV_VAR#${!ENV_VAR}#g" -i hardhat.config.ts;
+# Functions
+
+replace_placeholders() {
+	KEY="$1"
+	URL="$2"
+	if [[ -z "$KEY" ]] || [[ -z "$URL" ]]; then
+		echo "usage: replace_placeholders <key> <url>"
+		exit 1
+	fi
+
+	sed -i "s/KEY/$KEY/g;s#URL#$URL#g" ./hardhat.config.ts
+}
+
+spawn_eth_node() {
+	IP="$1"
+	PORT="$2"
+	OUT_FILE="$3"
+	if [[ -z "$IP" ]] || [[ -z "$PORT" ]]; then
+		echo "usage: spawn_eth_node <ip> <port>"
+		exit 1
+	fi
+
+	pnpm hardhat node --network hardhat --port "$PORT" --hostname "$IP" &
+	trap "kill $! 2>/dev/null" EXIT
+}
+
+wait_node_healthy() {
+	URL="$1"
+	if [[ -z "$URL" ]]; then
+		echo "usage: wait_node_healthy <url>"
+		exit 1
+	fi
+
+	RETRIES=${RETRIES:-120}
+	JSON='{"jsonrpc":"2.0","id":0,"method":"net_version","params":[]}'
+	curl \
+		--fail \
+		--silent \
+		-H "Content-Type: application/json" \
+		--retry-connrefused \
+		--retry "$RETRIES" \
+		--retry-delay 1 \
+		-d "$JSON" \
+		"$URL" >/dev/null
+}
+
+deploy_contracts() {
+	KEY="$1"
+	URL="$2"
+	if [[ -z "$KEY" ]] || [[ -z "$URL" ]]; then
+		echo "usage: deploy_contracts <key> <url>"
+		exit 1
+	fi
+	LOCALHOST_HTTP="$URL" DEPLOYER_KEY="$KEY" pnpm run node-deploy
+}
+
+usage() {
+	echo "Usage: $0 --key KEY [options]"
+	echo "  --key KEY    The private key to use for deployment"
+	echo "  -p, --port   Set the port number (default: ${PORT})"
+	echo "  -i, --ip     Set the IP address (default: ${IP})"
+	echo "  -h, --help   Display this help message"
+}
+
+# Main
+
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+	--key)
+		KEY="$2"
+		shift
+		;;
+	-p | --port)
+		PORT="$2"
+		shift
+		;;
+	-i | --ip)
+		IP="$2"
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "Unknown parameter passed: $1"
+		usage
+		exit 1
+		;;
+	esac
+	shift
 done
 
-(npm run node 2>&1 | tee node_err)& 
-# propagate SIGTERM to the node running in the background
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+if [[ -z "$KEY" ]]; then
+	echo "Error: KEY is required."
+	usage
+	exit 1
+fi
 
-while true; do
-    if grep -q -F 'Account #0: 0xBCcA9EcB933Db2481111102E73c61C7c7C4e2366 (10000 ETH)' node_err &> /dev/null ; then
-        break
-    fi
+URL="http://$IP:$PORT"
+replace_placeholders "$KEY" "$URL"
+spawn_eth_node "$IP" "$PORT"
 
-    sleep 1;
-done
+wait_node_healthy "$URL"
 
-yes Y | npm run script-deploy
-
-# part of health checking, so that we don't start the committer before the
-# deployment is done
+deploy_contracts "$KEY" "$URL"
 touch /contracts_deployed
 
 wait


### PR DESCRIPTION
fuel v2 contracts have been archived for some time. The e2e test of the committer will now use the contracts from the `fuel-bridge` repository. 