### PR TITLE
feat: support fuel-core 0.24.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
-  RUST_VERSION: 1.74.0
-  FUEL_CORE_VERSION: 0.22.0
+  RUST_VERSION: 1.77.0
+  FUEL_CORE_VERSION: 0.24.1
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-block-committer"
-rust-version = "1.74.0"
+rust-version = "1.77.0"
 version = "0.1.0"
 name = "fuel-block-committer"
 
@@ -16,7 +16,7 @@ path = "tests/harness.rs"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.68"
-fuel-core-client = "0.22.0"
+fuel-core-client = "0.24"
 prometheus = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 ethers = { version = "2.0", features = ["ws"] }
@@ -28,11 +28,12 @@ tracing-subscriber = { version = "0.3.17", features = ["json"] }
 clap = { version = "4.3", features = ["derive", "env"] }
 url = "2.3"
 serde_json = "1.0.96"
-rusqlite = { version = "0.30", features = ["bundled"] }
+rusqlite = { version = "0.31", features = ["bundled"] }
 futures = "0.3.28"
 
 [dev-dependencies]
-fuels-test-helpers = "0.54.0"
+#TODO: use once a new release supporting core 0.24.1 is made
+#fuels-test-helpers = "0.56.0"
 rand = "0.8.5"
-mockall = "0.11.4"
+mockall = "0.12.1"
 anyhow = "1.0.71"

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.22.1}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.24.1}"
     container_name: fuel-node
     environment:
       - PORT=4000
@@ -33,8 +33,8 @@ services:
     ports:
       - "4000:4000"
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "http://0.0.0.0:4000/health" ]
-      retries: 5
+      test: [ "CMD", "curl", "--fail", "http://0.0.0.0:4000/v1/health" ]
+      retries: 50
       interval: 2s
       timeout: 30s
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.74 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.77 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 

--- a/src/adapters/fuel_adapter/fuel_client.rs
+++ b/src/adapters/fuel_adapter/fuel_client.rs
@@ -57,7 +57,7 @@ impl FuelAdapter for FuelClient {
     async fn block_at_height(&self, height: u32) -> Result<Option<FuelBlock>> {
         let maybe_block = self
             .client
-            .block_by_height(height)
+            .block_by_height(height.into())
             .await
             .map_err(|e| Error::Network(e.to_string()))?;
 
@@ -80,60 +80,61 @@ impl FuelAdapter for FuelClient {
 
 #[cfg(test)]
 mod tests {
-    use fuels_test_helpers::{setup_test_provider, Config};
     use prometheus::{proto::Metric, Registry};
 
     use super::*;
 
-    #[tokio::test]
-    async fn can_fetch_latest_block() {
-        // given
-        let node_config = Config {
-            debug: true,
-            ..Default::default()
-        };
+    // TODO: once a sdk release is made these can be adapted
+    // #[tokio::test]
+    // async fn can_fetch_latest_block() {
+    //     // given
+    //     let node_config = Config {
+    //         debug: true,
+    //         ..Default::default()
+    //     };
+    //
+    //     let provider =
+    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
+    //             .await
+    //             .unwrap();
+    //     provider.produce_blocks(5, None).await.unwrap();
+    //
+    //     let addr = provider.url();
+    //     let url = Url::parse(addr).unwrap();
+    //     let fuel_adapter = FuelClient::new(&url, 1);
+    //
+    //     // when
+    //     let result = fuel_adapter.latest_block().await.unwrap();
+    //
+    //     // then
+    //     assert_eq!(result.height, 5);
+    // }
 
-        let provider =
-            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
-                .await
-                .unwrap();
-        provider.produce_blocks(5, None).await.unwrap();
-
-        let addr = provider.url();
-        let url = Url::parse(addr).unwrap();
-        let fuel_adapter = FuelClient::new(&url, 1);
-
-        // when
-        let result = fuel_adapter.latest_block().await.unwrap();
-
-        // then
-        assert_eq!(result.height, 5);
-    }
-
-    #[tokio::test]
-    async fn can_fetch_block_at_height() {
-        // given
-        let node_config = Config {
-            debug: true,
-            ..Default::default()
-        };
-
-        let provider =
-            setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
-                .await
-                .unwrap();
-        provider.produce_blocks(5, None).await.unwrap();
-
-        let url = Url::parse(provider.url()).unwrap();
-
-        let fuel_adapter = FuelClient::new(&url, 1);
-
-        // when
-        let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
-
-        // then
-        assert_eq!(result.height, 3);
-    }
+    // TODO: once a sdk release is made these can be adapted
+    // #[tokio::test]
+    // async fn can_fetch_block_at_height() {
+    //     // given
+    //     let node_config = Config {
+    //         debug: true,
+    //         ..Default::default()
+    //     };
+    //
+    //     let provider =
+    //         setup_test_provider(vec![], vec![], Some(node_config), Some(Default::default()))
+    //             .await
+    //             .unwrap();
+    //     provider.produce_blocks(5, None).await.unwrap();
+    //
+    //     let url = Url::parse(provider.url()).unwrap();
+    //
+    //     let fuel_adapter = FuelClient::new(&url, 1);
+    //
+    //     // when
+    //     let result = fuel_adapter.block_at_height(3).await.unwrap().unwrap();
+    //
+    //     // then
+    //     assert_eq!(result.height, 3);
+    // }
 
     #[tokio::test]
     async fn updates_metrics_in_case_of_network_err() {


### PR DESCRIPTION
Had to disable 2 integration tests checking whether we can communicate with fuel-core's API because `fuels-rs` hasn't had a release yet.

The same functionality is covered at a higher level with the `e2e` test so I'd say we're in the clear since the e2e test passes.

Once `fuels-rs` gets a release we can come back and uncomment the tests.