### PR TITLE
chore: bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-committer"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-block-committer"
 rust-version = "1.77.0"
-version = "0.1.0"
+version = "0.3.0"
 name = "fuel-block-committer"
 
 [[test]]

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -3,4 +3,4 @@ name: fuel-block-committer
 description: Fuel Block Committer Helm Chart
 type: application
 appVersion: "0.3.0"
-version: 0.1.0
+version: 0.1.1

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-block-committer
 description: Fuel Block Committer Helm Chart
 type: application
-appVersion: "0.1.0"
+appVersion: "0.3.0"
 version: 0.1.0


### PR DESCRIPTION
It seems the version wasn't bumped for the `0.2.0` release. Bumping it now to `0.3.0`.