### PR TITLE
chore: bump fuel core to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-committer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbbde8ee055ee506d8104d80a138b9f8554b1c87fb84471f5d2f4e9002c7649"
+checksum = "bc636a8706e36c713606ee4226fdef5260e3650ba0e8a57f0fc06258d0078a34"
 dependencies = [
  "anyhow",
  "cynic",
@@ -1839,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db88fcb920c9101021520b60c8481b4f959274d9f711dd6602cf993657adde2"
+checksum = "cf038dd8df8d3aa665a13295c9ef888ba8118600cccdf8fb4587410e0e102fdf"
 dependencies = [
  "anyhow",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/fuel-block-committer"
 rust-version = "1.77.0"
-version = "0.3.0"
+version = "0.4.0"
 name = "fuel-block-committer"
 
 [[test]]
@@ -16,7 +16,7 @@ path = "tests/harness.rs"
 [dependencies]
 actix-web = "4"
 async-trait = "0.1.68"
-fuel-core-client = "0.25.3"
+fuel-core-client = "0.26"
 prometheus = "0.13.3"
 serde = { version = "1.0", features = ["derive"] }
 ethers = { version = "2.0", features = ["ws"] }

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
     build:
       context: fuel_node
       args:
-        fuel_core_version: "v${FUEL_CORE_VERSION:-0.25.3}"
+        fuel_core_version: "v${FUEL_CORE_VERSION:-0.26.0}"
     container_name: fuel-node
     environment:
       - PORT=4000

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-block-committer
 description: Fuel Block Committer Helm Chart
 type: application
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 version: 0.1.1

--- a/eth_node/Dockerfile
+++ b/eth_node/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.19.1 AS fetcher
 RUN apk add --no-cache git 
 RUN git clone --no-checkout https://github.com/FuelLabs/fuel-bridge \
   && cd fuel-bridge \
-  && git checkout a5b15f1 \
+  && git checkout 97bb4ce \
   && cd packages/solidity-contracts \
   && rm -rf deploy deployments exports test \
   && cd contracts \

--- a/fuel-toolchain.toml
+++ b/fuel-toolchain.toml
@@ -1,6 +1,0 @@
-[toolchain]
-channel = "latest-2023-07-05"
-
-[components]
-forc = "0.44.0"
-fuel-core = "0.20.3"


### PR DESCRIPTION
Fuel core version bumped.

Also bumped the version of the committer to `0.4.0` to prepare for the release after this PR gets merged.