### PR TITLE
feat: add block signature validation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.11.3"
+version = "1.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba00838774b4ab0233e355d26710fbfc8327a05c017f6dc4873f876d1f79f78"
+checksum = "70ff96486ccc291d36a958107caf2c0af8c78c0af7d31ae2f35ce055130de1a6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1000,12 +1000,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.8",
- "darling_macro 0.20.8",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -1024,15 +1024,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim 0.11.1",
  "syn 2.0.63",
 ]
 
@@ -1049,11 +1049,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.8",
+ "darling_core 0.20.9",
  "quote",
  "syn 2.0.63",
 ]
@@ -1193,6 +1193,7 @@ dependencies = [
  "ports",
  "serde_json",
  "tokio",
+ "validator",
 ]
 
 [[package]]
@@ -1641,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "finl_unicode"
@@ -1741,6 +1742,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "validator",
 ]
 
 [[package]]
@@ -1788,16 +1790,12 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cef93970fb8a26d3a683ae211833c6bbf391066887f501bd5859f29992b59a"
 dependencies = [
- "coins-bip32",
- "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
  "fuel-types",
  "k256",
- "lazy_static",
  "p256",
  "rand",
- "secp256k1",
  "serde",
  "sha2",
  "zeroize",
@@ -3220,14 +3218,13 @@ dependencies = [
  "async-trait",
  "ethers-core",
  "fuel-core-client",
- "fuel-crypto",
  "futures",
  "impl-tools",
  "mockall",
  "rand",
  "serde",
- "tai64",
  "thiserror",
+ "validator",
 ]
 
 [[package]]
@@ -3767,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
@@ -3897,25 +3894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
-dependencies = [
- "rand",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3970,18 +3948,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4012,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
 dependencies = [
  "serde",
 ]
@@ -4055,7 +4033,7 @@ version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
- "darling 0.20.8",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -4079,6 +4057,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "validator",
 ]
 
 [[package]]
@@ -4818,21 +4797,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.12",
+ "toml_edit 0.22.13",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -4850,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -5103,6 +5082,19 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "validator"
+version = "0.4.0"
+dependencies = [
+ "fuel-core-client",
+ "fuel-crypto",
+ "mockall",
+ "rand",
+ "serde",
+ "tai64",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
 
 [[package]]
 name = "arrayvec"
@@ -330,7 +330,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -370,7 +370,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 
 [[package]]
 name = "cfg-if"
@@ -661,7 +661,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1033,7 +1033,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1055,7 +1055,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1191,6 +1191,7 @@ dependencies = [
  "eth",
  "fuel",
  "ports",
+ "serde_json",
  "tokio",
 ]
 
@@ -1298,9 +1299,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1466,7 +1467,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.60",
+ "syn 2.0.63",
  "toml",
  "walkdir",
 ]
@@ -1484,7 +1485,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1510,7 +1511,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
- "syn 2.0.60",
+ "syn 2.0.63",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1787,11 +1788,16 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cef93970fb8a26d3a683ae211833c6bbf391066887f501bd5859f29992b59a"
 dependencies = [
+ "coins-bip32",
+ "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
  "fuel-types",
  "k256",
+ "lazy_static",
  "p256",
+ "rand",
+ "secp256k1",
  "serde",
  "sha2",
  "zeroize",
@@ -1805,7 +1811,7 @@ checksum = "2b85e8e508b26d088262075fcfe9921b7009c931fef1cc55fe1dafb116c99884"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
  "synstructure",
 ]
 
@@ -1860,6 +1866,7 @@ checksum = "455cf5275d96f6907e81ed1825c4e6a9dd79f7c1c37a4e15134562f83024c7e7"
 dependencies = [
  "fuel-derive",
  "hex",
+ "rand",
  "serde",
 ]
 
@@ -1978,7 +1985,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2043,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2510,7 +2517,7 @@ dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2522,7 +2529,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2831,7 +2838,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2846,11 +2853,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2933,10 +2939,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3005,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3019,11 +3025,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.9"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3074,14 +3080,14 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3159,7 +3165,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3213,11 +3219,14 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "ethers-core",
+ "fuel-core-client",
+ "fuel-crypto",
  "futures",
  "impl-tools",
  "mockall",
  "rand",
  "serde",
+ "tai64",
  "thiserror",
 ]
 
@@ -3273,12 +3282,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3302,25 +3311,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
-dependencies = [
- "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -3357,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3658,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hex"
@@ -3750,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -3777,15 +3767,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "salsa20"
@@ -3807,9 +3797,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c453e59a955f81fb62ee5d596b450383d699f152d350e9d23a0db2adb78e4c0"
+checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -3819,11 +3809,11 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18cf6c6447f813ef19eb450e985bcce6705f9ce7660db221b59093d15c79c4b7"
+checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3907,6 +3897,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3940,9 +3949,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
@@ -3961,29 +3970,29 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -3998,7 +4007,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4049,7 +4058,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4057,6 +4066,7 @@ name = "services"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "fuel-crypto",
  "futures",
  "metrics",
  "mockall",
@@ -4064,6 +4074,7 @@ dependencies = [
  "rand",
  "serde",
  "storage",
+ "tai64",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -4453,7 +4464,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4464,7 +4475,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4508,7 +4519,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4530,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4553,7 +4564,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4635,22 +4646,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4745,7 +4756,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -4828,28 +4839,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
-dependencies = [
- "indexmap 2.2.6",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
@@ -4920,7 +4909,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5192,7 +5181,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -5226,7 +5215,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5500,22 +5489,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087eca3c1eaf8c47b94d02790dd086cd594b912d2043d4de4bfdd466b3befb7c"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.33"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4b6c273f496d8fd4eaf18853e6b448760225dc030ff2c485a786859aea6393"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -5535,5 +5524,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.63",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ config = { version = "0.14", default-features = false }
 ethers = { version = "2.0", default-features = false }
 ethers-core = { version = "2.0", default-features = false }
 fuel-core-client = { version = "0.26", default-features = false }
+fuel-crypto = { version = "0.49.0" }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false }
 impl-tools = { version = "0.10.0", default-features = false }
@@ -46,6 +47,7 @@ rand = { version = "0.8", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sqlx = { version = "0.7.4", default-features = false }
+tai64 = { version = "4.0.0", default-features = false }
 testcontainers = { version = "0.16", default-features = false }
 thiserror = { version = "1.0", default-features = false }
 tokio = { version = "1.37", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "packages/ports",
   "packages/services",
   "packages/storage",
+  "packages/validator",
 ]
 
 [workspace.package]
@@ -28,6 +29,7 @@ metrics = { path = "./packages/metrics", default-features = false }
 ports = { path = "./packages/ports", default-features = false }
 storage = { path = "./packages/storage", default-features = false }
 services = { path = "./packages/services", default-features = false }
+validator = { path = "./packages/validator", default-features = false }
 
 actix-web = { version = "4", default-features = false }
 anyhow = { version = "1.0", default-features = false }
@@ -37,7 +39,7 @@ config = { version = "0.14", default-features = false }
 ethers = { version = "2.0", default-features = false }
 ethers-core = { version = "2.0", default-features = false }
 fuel-core-client = { version = "0.26", default-features = false }
-fuel-crypto = { version = "0.49.0" }
+fuel-crypto = { version = "0.49.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false }
 impl-tools = { version = "0.10.0", default-features = false }

--- a/committer/Cargo.toml
+++ b/committer/Cargo.toml
@@ -27,6 +27,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 url = { workspace = true }
+validator = { workspace = true, features = ["validator"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -18,6 +18,8 @@ pub struct FuelConfig {
     /// URL to a fuel-core graphql endpoint.
     #[serde(deserialize_with = "parse_url")]
     pub graphql_endpoint: Url,
+    /// Block producer public key
+    pub block_producer_public_key: ports::fuel::FuelPublicKey,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/committer/src/errors.rs
+++ b/committer/src/errors.rs
@@ -57,7 +57,8 @@ impl From<services::Error> for Error {
         match error {
             services::Error::Network(e) => Self::Network(e),
             services::Error::Storage(e) => Self::Storage(e),
-            _ => Self::Other(error.to_string()),
+            services::Error::BlockValidation(e) => Self::Other(e),
+            services::Error::Other(e) => Self::Other(e),
         }
     }
 }

--- a/committer/src/errors.rs
+++ b/committer/src/errors.rs
@@ -48,6 +48,7 @@ impl From<ports::fuel::Error> for Error {
     fn from(value: ports::fuel::Error) -> Self {
         match value {
             ports::fuel::Error::Network(e) => Self::Network(e),
+            _ => Self::Other(value.to_string()),
         }
     }
 }

--- a/committer/src/errors.rs
+++ b/committer/src/errors.rs
@@ -5,15 +5,15 @@ use tokio::task::JoinError;
 pub enum Error {
     #[error("{0}")]
     Other(String),
-    #[error("Network Error: {0}")]
+    #[error("Network error: {0}")]
     Network(String),
     #[error("Storage error: {0}")]
     Storage(String),
 }
 
 impl From<serde_json::Error> for Error {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Other(value.to_string())
+    fn from(error: serde_json::Error) -> Self {
+        Self::Other(error.to_string())
     }
 }
 
@@ -36,19 +36,18 @@ impl From<ports::storage::Error> for Error {
 }
 
 impl From<ports::l1::Error> for Error {
-    fn from(value: ports::l1::Error) -> Self {
-        match value {
+    fn from(error: ports::l1::Error) -> Self {
+        match error {
             ports::l1::Error::Network(e) => Self::Network(e),
-            _ => Self::Other(value.to_string()),
+            _ => Self::Other(error.to_string()),
         }
     }
 }
 
 impl From<ports::fuel::Error> for Error {
-    fn from(value: ports::fuel::Error) -> Self {
-        match value {
+    fn from(error: ports::fuel::Error) -> Self {
+        match error {
             ports::fuel::Error::Network(e) => Self::Network(e),
-            _ => Self::Other(value.to_string()),
         }
     }
 }
@@ -58,7 +57,7 @@ impl From<services::Error> for Error {
         match error {
             services::Error::Network(e) => Self::Network(e),
             services::Error::Storage(e) => Self::Storage(e),
-            services::Error::Other(e) => Self::Other(e),
+            _ => Self::Other(error.to_string()),
         }
     }
 }

--- a/committer/src/main.rs
+++ b/committer/src/main.rs
@@ -19,6 +19,7 @@ use crate::setup::shut_down;
 pub type L1 = eth::WebsocketClient;
 pub type Database = storage::Postgres;
 pub type FuelApi = fuel::HttpClient;
+pub type Validator = validator::BlockValidator;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/committer/src/setup.rs
+++ b/committer/src/setup.rs
@@ -6,11 +6,12 @@ use services::{BlockCommitter, BlockWatcher, CommitListener, Runner, WalletBalan
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
+use validator::BlockValidator;
 
 use crate::{
     config::{Config, InternalConfig},
     errors::Result,
-    Database, FuelApi, L1,
+    Database, FuelApi, Validator, L1,
 };
 
 pub fn spawn_block_watcher(
@@ -161,7 +162,7 @@ fn create_block_watcher(
     fuel_adapter: FuelApi,
     storage: Database,
 ) -> (
-    BlockWatcher<FuelApi, Database>,
+    BlockWatcher<FuelApi, Database, Validator>,
     Receiver<ValidatedFuelBlock>,
 ) {
     let (tx_fuel_block, rx_fuel_block) = tokio::sync::mpsc::channel(100);
@@ -170,7 +171,7 @@ fn create_block_watcher(
         tx_fuel_block,
         fuel_adapter,
         storage,
-        config.fuel.block_producer_public_key,
+        BlockValidator::new(config.fuel.block_producer_public_key),
     );
     block_watcher.register_metrics(registry);
 

--- a/committer/src/setup.rs
+++ b/committer/src/setup.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use metrics::{prometheus::Registry, HealthChecker, RegistersMetrics};
-use ports::{storage::Storage, types::FuelBlock};
+use ports::{storage::Storage, types::ValidatedFuelBlock};
 use services::{BlockCommitter, BlockWatcher, CommitListener, Runner, WalletBalanceTracker};
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
@@ -20,7 +20,7 @@ pub fn spawn_block_watcher(
     registry: &Registry,
     cancel_token: CancellationToken,
 ) -> (
-    Receiver<FuelBlock>,
+    Receiver<ValidatedFuelBlock>,
     tokio::task::JoinHandle<()>,
     HealthChecker,
 ) {
@@ -59,7 +59,7 @@ pub fn spawn_wallet_balance_tracker(
 
 pub fn spawn_l1_committer_and_listener(
     internal_config: &InternalConfig,
-    rx_fuel_block: Receiver<FuelBlock>,
+    rx_fuel_block: Receiver<ValidatedFuelBlock>,
     l1: L1,
     storage: Database,
     registry: &Registry,
@@ -81,7 +81,7 @@ pub fn spawn_l1_committer_and_listener(
 }
 
 fn create_block_committer(
-    rx_fuel_block: Receiver<FuelBlock>,
+    rx_fuel_block: Receiver<ValidatedFuelBlock>,
     l1: L1,
     storage: impl Storage + 'static,
 ) -> tokio::task::JoinHandle<()> {
@@ -160,13 +160,17 @@ fn create_block_watcher(
     registry: &Registry,
     fuel_adapter: FuelApi,
     storage: Database,
-) -> (BlockWatcher<FuelApi, Database>, Receiver<FuelBlock>) {
+) -> (
+    BlockWatcher<FuelApi, Database>,
+    Receiver<ValidatedFuelBlock>,
+) {
     let (tx_fuel_block, rx_fuel_block) = tokio::sync::mpsc::channel(100);
     let block_watcher = BlockWatcher::new(
         config.eth.commit_interval,
         tx_fuel_block,
         fuel_adapter,
         storage,
+        config.fuel.block_producer_public_key,
     );
     block_watcher.register_metrics(registry);
 

--- a/configurations/development/config.toml
+++ b/configurations/development/config.toml
@@ -7,6 +7,7 @@ rpc = "ws://localhost:8089"
 
 [fuel]
 graphql_endpoint = "http://localhost:4000"
+block_producer_public_key = "0x73dc6cc8cc0041e4924954b35a71a22ccb520664c522198a6d31dc6c945347bb854a39382d296ec64c70d7cea1db75601595e29729f3fbdc7ee9dae66705beb4"
 
 [app]
 port = 8080

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -14,4 +14,5 @@ anyhow = { workspace = true }
 eth = { workspace = true, features = ["test-helpers"] }
 fuel = { workspace = true, features = ["test-helpers"] }
 ports = { workspace = true, features = ["fuel", "l1"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -16,3 +16,4 @@ fuel = { workspace = true, features = ["test-helpers"] }
 ports = { workspace = true, features = ["fuel", "l1"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+validator = { workspace = true, features = ["validator"] }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -32,6 +32,7 @@ mod tests {
 
         let latest_block = provider.latest_block().await?;
 
+        // Had to use `serde_json` because `FromStr` did not work because of an validation error
         let producer_public_key: FuelPublicKey = serde_json::from_str("\"0x73dc6cc8cc0041e4924954b35a71a22ccb520664c522198a6d31dc6c945347bb854a39382d296ec64c70d7cea1db75601595e29729f3fbdc7ee9dae66705beb4\"")
                  .map_err(|e| anyhow!("could not parse producer pub key: {e:?}"))?;
 

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -5,10 +5,8 @@ mod tests {
     use anyhow::{anyhow, Result};
     use eth::{Chain, WebsocketClient};
     use fuel::HttpClient;
-    use ports::{
-        fuel::{Api, FuelPublicKey},
-        types::ValidatedFuelBlock,
-    };
+    use ports::fuel::{Api, FuelPublicKey};
+    use validator::{BlockValidator, Validator};
 
     const FUEL_NODE_PORT: u16 = 4000;
 
@@ -37,7 +35,7 @@ mod tests {
         let producer_public_key: FuelPublicKey = serde_json::from_str("\"0x73dc6cc8cc0041e4924954b35a71a22ccb520664c522198a6d31dc6c945347bb854a39382d296ec64c70d7cea1db75601595e29729f3fbdc7ee9dae66705beb4\"")
                  .map_err(|e| anyhow!("could not parse producer pub key: {e:?}"))?;
 
-        let validated_block = ValidatedFuelBlock::from(&latest_block, &producer_public_key)?;
+        let validated_block = BlockValidator::new(producer_public_key).validate(&latest_block)?;
 
         assert!(fuel_contract.finalized(validated_block).await?);
 

--- a/packages/eth/src/lib.rs
+++ b/packages/eth/src/lib.rs
@@ -16,7 +16,7 @@ pub use websocket::WebsocketClient;
 
 #[async_trait]
 impl ports::l1::Contract for WebsocketClient {
-    async fn submit(&self, block: ports::types::FuelBlock) -> ports::l1::Result<()> {
+    async fn submit(&self, block: ports::types::ValidatedFuelBlock) -> ports::l1::Result<()> {
         self.submit(block).await
     }
 

--- a/packages/eth/src/websocket.rs
+++ b/packages/eth/src/websocket.rs
@@ -4,7 +4,7 @@ use ::metrics::{prometheus::core::Collector, HealthChecker, RegistersMetrics};
 use ethers::types::{Address, Chain};
 use ports::{
     l1::Result,
-    types::{FuelBlock, U256},
+    types::{ValidatedFuelBlock, U256},
 };
 use url::Url;
 
@@ -50,7 +50,7 @@ impl WebsocketClient {
         self.inner.event_streamer(eth_block_height)
     }
 
-    pub(crate) async fn submit(&self, block: FuelBlock) -> Result<()> {
+    pub(crate) async fn submit(&self, block: ValidatedFuelBlock) -> Result<()> {
         Ok(self.inner.submit(block).await?)
     }
 
@@ -63,7 +63,7 @@ impl WebsocketClient {
     }
 
     #[cfg(feature = "test-helpers")]
-    pub async fn finalized(&self, block: FuelBlock) -> Result<bool> {
+    pub async fn finalized(&self, block: ValidatedFuelBlock) -> Result<bool> {
         Ok(self.inner.finalized(block).await?)
     }
 

--- a/packages/eth/src/websocket/connection.rs
+++ b/packages/eth/src/websocket/connection.rs
@@ -6,7 +6,7 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::{Address, Chain, H160, U256, U64},
 };
-use ports::types::FuelBlock;
+use ports::types::ValidatedFuelBlock;
 use serde_json::Value;
 use url::Url;
 
@@ -33,9 +33,9 @@ pub struct WsConnection {
 
 #[async_trait::async_trait]
 impl EthApi for WsConnection {
-    async fn submit(&self, block: FuelBlock) -> Result<()> {
-        let commit_height = Self::calculate_commit_height(block.height, self.commit_interval);
-        let contract_call = self.contract.commit(block.hash, commit_height);
+    async fn submit(&self, block: ValidatedFuelBlock) -> Result<()> {
+        let commit_height = Self::calculate_commit_height(block.height(), self.commit_interval);
+        let contract_call = self.contract.commit(block.hash(), commit_height);
         let tx = contract_call.send().await?;
 
         tracing::info!("tx: {} submitted", tx.tx_hash());
@@ -70,10 +70,10 @@ impl EthApi for WsConnection {
     }
 
     #[cfg(feature = "test-helpers")]
-    async fn finalized(&self, block: FuelBlock) -> Result<bool> {
+    async fn finalized(&self, block: ValidatedFuelBlock) -> Result<bool> {
         Ok(self
             .contract
-            .finalized(block.hash, block.height.into())
+            .finalized(block.hash(), block.height().into())
             .call()
             .await?)
     }

--- a/packages/fuel/src/lib.rs
+++ b/packages/fuel/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(unused_crate_dependencies)]
-use fuel_core_client::client::types::Block;
-use ports::types::FuelBlock;
+use ports::fuel::FuelBlock;
 mod client;
 mod metrics;
 
@@ -9,22 +8,14 @@ pub use client::*;
 type Error = ports::fuel::Error;
 type Result<T> = ports::fuel::Result<T>;
 
-fn convert_block(block: Block) -> FuelBlock {
-    FuelBlock {
-        hash: *block.id,
-        height: block.header.height,
-    }
-}
-
 #[async_trait::async_trait]
 impl ports::fuel::Api for client::HttpClient {
     async fn block_at_height(&self, height: u32) -> ports::fuel::Result<Option<FuelBlock>> {
-        Ok(self._block_at_height(height).await?.map(convert_block))
+        self._block_at_height(height).await
     }
 
     async fn latest_block(&self) -> ports::fuel::Result<FuelBlock> {
-        let block = self._latest_block().await?;
-        Ok(convert_block(block))
+        self._latest_block().await
     }
 }
 

--- a/packages/ports/Cargo.toml
+++ b/packages/ports/Cargo.toml
@@ -12,22 +12,18 @@ rust-version = { workspace = true }
 [dependencies]
 async-trait = { workspace = true, optional = true }
 ethers-core = { workspace = true, optional = true }
+fuel-core-client = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
-fuel-core-client = { workspace = true }
-fuel-crypto = { workspace = true }
 impl-tools = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true, optional = true }
-
-[dev-dependencies]
-fuel-crypto = { workspace = true, features = ["random"] }
-tai64 = { workspace = true }
+validator = { workspace = true, optional = true }
 
 [features]
 test-helpers = ["dep:mockall", "dep:rand"]
 l1 = ["dep:ethers-core", "dep:futures", "dep:thiserror", "dep:async-trait"]
-fuel = ["dep:thiserror", "dep:async-trait"]
+fuel = ["dep:thiserror", "dep:async-trait", "dep:fuel-core-client", "dep:validator"]
 storage = ["dep:impl-tools", "dep:thiserror", "dep:async-trait"]
 full = ["l1", "fuel", "storage"]

--- a/packages/ports/Cargo.toml
+++ b/packages/ports/Cargo.toml
@@ -13,11 +13,17 @@ rust-version = { workspace = true }
 async-trait = { workspace = true, optional = true }
 ethers-core = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+fuel-core-client = { workspace = true }
+fuel-crypto = { workspace = true }
 impl-tools = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true, optional = true }
+
+[dev-dependencies]
+fuel-crypto = { workspace = true, features = ["random"] }
+tai64 = { workspace = true }
 
 [features]
 test-helpers = ["dep:mockall", "dep:rand"]

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -10,8 +10,6 @@ pub use fuel_core_client::client::types::{
 pub enum Error {
     #[error("{0}")]
     Network(String),
-    #[error("{0}")]
-    BlockValidation(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -1,9 +1,17 @@
-use crate::types::FuelBlock;
+pub use fuel_core_client::client::types::{
+    block::{
+        Block as FuelBlock, Consensus as FuelConsensus, Header as FuelHeader,
+        PoAConsensus as FuelPoAConsensus,
+    },
+    primitives::{BlockId as FuelBlockId, Bytes32 as FuelBytes32, PublicKey as FuelPublicKey},
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]
     Network(String),
+    #[error("{0}")]
+    BlockValidation(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/packages/ports/src/ports/l1.rs
+++ b/packages/ports/src/ports/l1.rs
@@ -1,6 +1,8 @@
 use std::pin::Pin;
 
-use crate::types::{FuelBlock, FuelBlockCommittedOnL1, InvalidL1Height, L1Height, Stream, U256};
+use crate::types::{
+    FuelBlockCommittedOnL1, InvalidL1Height, L1Height, Stream, ValidatedFuelBlock, U256,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -21,7 +23,7 @@ impl From<InvalidL1Height> for Error {
 #[cfg_attr(feature = "test-helpers", mockall::automock)]
 #[async_trait::async_trait]
 pub trait Contract: Send + Sync {
-    async fn submit(&self, block: FuelBlock) -> Result<()>;
+    async fn submit(&self, block: ValidatedFuelBlock) -> Result<()>;
     fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync>;
 }
 

--- a/packages/ports/src/types.rs
+++ b/packages/ports/src/types.rs
@@ -4,13 +4,13 @@ pub use ethers_core::types::{H160, U256};
 pub use futures::Stream;
 
 mod block_submission;
-mod fuel_block;
 #[cfg(feature = "l1")]
 mod fuel_block_committed_on_l1;
 mod l1_height;
 
 pub use block_submission::*;
-pub use fuel_block::*;
 #[cfg(feature = "l1")]
 pub use fuel_block_committed_on_l1::*;
 pub use l1_height::*;
+#[cfg(feature = "fuel")]
+pub use validator::block::*;

--- a/packages/ports/src/types/block_submission.rs
+++ b/packages/ports/src/types/block_submission.rs
@@ -1,8 +1,9 @@
-use crate::types::{L1Height, ValidatedFuelBlock};
+use crate::types::L1Height;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockSubmission {
-    pub block: ValidatedFuelBlock,
+    pub block_hash: [u8; 32],
+    pub block_height: u32,
     pub completed: bool,
     // L1 block height moments before submitting the fuel block. Used to filter stale events in
     // the commit listener.
@@ -13,7 +14,8 @@ pub struct BlockSubmission {
 impl rand::distributions::Distribution<BlockSubmission> for rand::distributions::Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> BlockSubmission {
         BlockSubmission {
-            block: rng.gen(),
+            block_hash: rng.gen(),
+            block_height: rng.gen(),
             completed: rng.gen(),
             submittal_height: rng.gen(),
         }

--- a/packages/ports/src/types/block_submission.rs
+++ b/packages/ports/src/types/block_submission.rs
@@ -1,8 +1,8 @@
-use crate::types::{FuelBlock, L1Height};
+use crate::types::{L1Height, ValidatedFuelBlock};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockSubmission {
-    pub block: FuelBlock,
+    pub block: ValidatedFuelBlock,
     pub completed: bool,
     // L1 block height moments before submitting the fuel block. Used to filter stale events in
     // the commit listener.

--- a/packages/ports/src/types/fuel_block.rs
+++ b/packages/ports/src/types/fuel_block.rs
@@ -1,27 +1,305 @@
+use crate::ports::fuel::{
+    Error, FuelBlockId, FuelBytes32, FuelConsensus, FuelHeader, FuelPoAConsensus, FuelPublicKey,
+    Result,
+};
+use fuel_core_client::client::types::Block as FuelBlock;
+use fuel_crypto::{Hasher, Message};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
-pub struct FuelBlock {
-    pub hash: [u8; 32],
-    pub height: u32,
+pub struct ValidatedFuelBlock {
+    hash: [u8; 32],
+    height: u32,
+}
+
+impl ValidatedFuelBlock {
+    /// Create `ValidatedFuelBlock` from `FuelBlock` validating
+    /// public key, block id and signature.
+    pub fn from(fuel_block: &FuelBlock, expected_pub_key: &FuelPublicKey) -> Result<Self> {
+        Self::validate_public_key(fuel_block, expected_pub_key)?;
+        Self::validate_block_id(fuel_block)?;
+        Self::validate_block_signature(fuel_block, expected_pub_key)?;
+
+        Ok(Self {
+            hash: *fuel_block.id,
+            height: fuel_block.header.height,
+        })
+    }
+
+    fn validate_public_key(fuel_block: &FuelBlock, expected_pub_key: &FuelPublicKey) -> Result<()> {
+        let Some(producer_pub_key) = fuel_block.block_producer() else {
+            return Err(Error::BlockValidation(
+                "producer public key not found in fuel block".to_string(),
+            ));
+        };
+
+        if producer_pub_key != expected_pub_key {
+            return Err(Error::BlockValidation(format!(
+                "producer public key `{producer_pub_key:x}` does not match \
+                 expected public key `{expected_pub_key:x}`."
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_block_id(fuel_block: &FuelBlock) -> Result<()> {
+        let calculated_block_id = Self::calculate_block_id(fuel_block);
+        if fuel_block.id != calculated_block_id {
+            return Err(Error::BlockValidation(format!(
+                "fuel block id `{:x}` does not match \
+                 calculated block id `{calculated_block_id:x}`.",
+                fuel_block.id,
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_block_signature(
+        fuel_block: &FuelBlock,
+        expected_pub_key: &FuelPublicKey,
+    ) -> Result<()> {
+        let FuelConsensus::PoAConsensus(FuelPoAConsensus { signature }) = fuel_block.consensus
+        else {
+            return Err(Error::BlockValidation(
+                "PoAConsensus signature not found in fuel block".to_string(),
+            ));
+        };
+
+        let block_id_message = Message::from_bytes(*fuel_block.id);
+
+        signature
+            .verify(expected_pub_key, &block_id_message)
+            .map_err(|_| {
+                Error::BlockValidation(format!(
+                    "signature validation failed for fuel block with id: `{:x}`",
+                    fuel_block.id
+                ))
+            })?;
+
+        Ok(())
+    }
+
+    fn calculate_block_id(fuel_block: &FuelBlock) -> FuelBlockId {
+        let application_hash = Self::application_hash(&fuel_block.header);
+
+        let mut hasher = Hasher::default();
+        let FuelHeader {
+            prev_root,
+            height,
+            time,
+            ..
+        } = &fuel_block.header;
+
+        hasher.input(prev_root.as_ref());
+        hasher.input(height.to_be_bytes());
+        hasher.input(time.0.to_be_bytes());
+        hasher.input(application_hash.as_ref());
+
+        FuelBlockId::from(hasher.digest())
+    }
+
+    fn application_hash(header: &FuelHeader) -> FuelBytes32 {
+        // Order matters and is the same as the spec.
+        let mut hasher = Hasher::default();
+        let FuelHeader {
+            da_height,
+            consensus_parameters_version,
+            state_transition_bytecode_version,
+            transactions_count,
+            message_receipt_count,
+            transactions_root,
+            message_outbox_root,
+            event_inbox_root,
+            ..
+        } = header;
+
+        hasher.input(da_height.to_be_bytes());
+        hasher.input(consensus_parameters_version.to_be_bytes());
+        hasher.input(state_transition_bytecode_version.to_be_bytes());
+        hasher.input(transactions_count.to_be_bytes());
+        hasher.input(message_receipt_count.to_be_bytes());
+        hasher.input(transactions_root.as_ref());
+        hasher.input(message_outbox_root.as_ref());
+        hasher.input(event_inbox_root.as_ref());
+
+        hasher.digest()
+    }
+
+    /// # Safety
+    ///
+    /// This function should only be called when the caller can guarantee that
+    /// `hash` and `height` meet all the requirements normally enforced by `validate`.
+    pub unsafe fn new_unchecked(hash: [u8; 32], height: u32) -> Self {
+        Self { hash, height }
+    }
+
+    pub fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[cfg(feature = "test-helpers")]
+    pub fn new(hash: [u8; 32], height: u32) -> Self {
+        Self { hash, height }
+    }
+
+    #[cfg(feature = "test-helpers")]
+    pub fn set_height(&mut self, height: u32) {
+        self.height = height;
+    }
 }
 
 #[cfg(feature = "test-helpers")]
-impl rand::distributions::Distribution<FuelBlock> for rand::distributions::Standard {
-    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> FuelBlock {
-        FuelBlock {
+impl From<FuelBlock> for ValidatedFuelBlock {
+    fn from(block: FuelBlock) -> Self {
+        Self {
+            hash: *block.id,
+            height: block.header.height,
+        }
+    }
+}
+
+#[cfg(feature = "test-helpers")]
+impl rand::distributions::Distribution<ValidatedFuelBlock> for rand::distributions::Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> ValidatedFuelBlock {
+        ValidatedFuelBlock {
             hash: rng.gen(),
             height: rng.gen(),
         }
     }
 }
 
-impl std::fmt::Debug for FuelBlock {
+impl std::fmt::Debug for ValidatedFuelBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hash = self.hash.map(|byte| format!("{byte:02x?}")).join("");
         f.debug_struct("FuelBlock")
             .field("hash", &hash)
             .field("height", &self.height)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fuel_crypto::{SecretKey, Signature};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    #[should_panic(expected = "producer public key not found in fuel block")]
+    fn validate_public_key_missing() {
+        let fuel_block = given_a_block(None);
+
+        ValidatedFuelBlock::from(&fuel_block, &FuelPublicKey::default()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "does not match expected public key")]
+    fn validate_public_key_mistmach() {
+        let secret_key = given_secret_key();
+        let fuel_block = given_a_block(Some(secret_key));
+
+        ValidatedFuelBlock::from(&fuel_block, &FuelPublicKey::default()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "does not match calculated block id")]
+    fn validate_block_id_mistmach() {
+        let secret_key = given_secret_key();
+        let mut fuel_block = given_a_block(Some(secret_key));
+        fuel_block.header.height = 42; // Change a value to get a different block id
+
+        ValidatedFuelBlock::from(&fuel_block, &secret_key.public_key()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "PoAConsensus signature not found in fuel block")]
+    fn validate_block_consensus_not_poa() {
+        let secret_key = given_secret_key();
+        let mut fuel_block = given_a_block(Some(secret_key));
+        fuel_block.consensus = FuelConsensus::Unknown;
+
+        ValidatedFuelBlock::from(&fuel_block, &secret_key.public_key()).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "signature validation failed for fuel block with id:")]
+    fn validate_block_consensus_invalid_signature() {
+        let secret_key = given_secret_key();
+        let mut fuel_block = given_a_block(Some(secret_key));
+        fuel_block.consensus = FuelConsensus::PoAConsensus(FuelPoAConsensus {
+            signature: Signature::default(),
+        });
+
+        ValidatedFuelBlock::from(&fuel_block, &secret_key.public_key()).unwrap();
+    }
+
+    #[test]
+    fn validate_fuel_block() {
+        let secret_key = given_secret_key();
+        let fuel_block = given_a_block(Some(secret_key));
+
+        ValidatedFuelBlock::from(&fuel_block, &secret_key.public_key()).unwrap();
+    }
+
+    fn given_secret_key() -> SecretKey {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        SecretKey::random(&mut rng)
+    }
+
+    fn given_a_block(secret_key: Option<SecretKey>) -> FuelBlock {
+        let header = given_header();
+        let id: FuelBytes32 = "0x57131ec6e99caafc08803aa946093e02c4303a305e5cc959ad84b775e668a5c3"
+            .parse()
+            .unwrap();
+
+        if let Some(secret_key) = secret_key {
+            let id_message = Message::from_bytes(*id);
+            let signature = Signature::sign(&secret_key, &id_message);
+
+            FuelBlock {
+                id,
+                header,
+                consensus: FuelConsensus::PoAConsensus(FuelPoAConsensus { signature }),
+                transactions: vec![],
+                block_producer: Some(secret_key.public_key()),
+            }
+        } else {
+            FuelBlock {
+                id,
+                header,
+                consensus: FuelConsensus::Unknown,
+                transactions: vec![],
+                block_producer: None,
+            }
+        }
+    }
+
+    fn given_header() -> FuelHeader {
+        let application_hash = "0x017ab4b70ea129c29e932d44baddc185ad136bf719c4ada63a10b5bf796af91e"
+            .parse()
+            .unwrap();
+
+        FuelHeader {
+            id: Default::default(),
+            da_height: Default::default(),
+            consensus_parameters_version: Default::default(),
+            state_transition_bytecode_version: Default::default(),
+            transactions_count: Default::default(),
+            message_receipt_count: Default::default(),
+            transactions_root: Default::default(),
+            message_outbox_root: Default::default(),
+            event_inbox_root: Default::default(),
+            height: Default::default(),
+            prev_root: Default::default(),
+            time: tai64::Tai64(0),
+            application_hash,
+        }
     }
 }

--- a/packages/services/Cargo.toml
+++ b/packages/services/Cargo.toml
@@ -15,14 +15,16 @@ futures = { workspace = true }
 metrics = { workspace = true }
 ports = { workspace = true, features = ["full"] }
 serde = { workspace = true }
-tai64 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+validator = { workspace = true }
 
 [dev-dependencies]
 fuel-crypto = { workspace = true, features = ["random"] }
 mockall = { workspace = true }
 rand = { workspace = true }
 storage = { workspace = true, features = ["test-helpers"] }
+tai64 = { workspace = true }
+validator = { workspace = true, features = ["test-helpers"] }

--- a/packages/services/Cargo.toml
+++ b/packages/services/Cargo.toml
@@ -15,12 +15,14 @@ futures = { workspace = true }
 metrics = { workspace = true }
 ports = { workspace = true, features = ["full"] }
 serde = { workspace = true }
+tai64 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+fuel-crypto = { workspace = true, features = ["random"] }
 mockall = { workspace = true }
 rand = { workspace = true }
 storage = { workspace = true, features = ["test-helpers"] }

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -38,7 +38,8 @@ where
         let submittal_height = self.l1.get_block_number().await?;
 
         let submission = BlockSubmission {
-            block: fuel_block,
+            block_hash: fuel_block.hash(),
+            block_height: fuel_block.height(),
             submittal_height,
             completed: false,
         };
@@ -130,7 +131,7 @@ mod tests {
 
         // then
         let last_submission = db.submission_w_latest_block().await.unwrap().unwrap();
-        assert_eq!(expected_height, last_submission.block.height());
+        assert_eq!(expected_height, last_submission.block_height);
     }
 
     fn given_l1_that_expects_submission(block: ValidatedFuelBlock) -> MockL1 {

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ports::{
     storage::Storage,
-    types::{BlockSubmission, FuelBlock},
+    types::{BlockSubmission, ValidatedFuelBlock},
 };
 use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
@@ -10,13 +10,13 @@ use super::Runner;
 use crate::Result;
 
 pub struct BlockCommitter<C, Db> {
-    rx_block: Receiver<FuelBlock>,
+    rx_block: Receiver<ValidatedFuelBlock>,
     l1: C,
     storage: Db,
 }
 
 impl<L1, Db> BlockCommitter<L1, Db> {
-    pub fn new(rx_block: Receiver<FuelBlock>, l1: L1, storage: Db) -> Self {
+    pub fn new(rx_block: Receiver<ValidatedFuelBlock>, l1: L1, storage: Db) -> Self {
         Self {
             rx_block,
             l1,
@@ -24,7 +24,7 @@ impl<L1, Db> BlockCommitter<L1, Db> {
         }
     }
 
-    async fn next_fuel_block_for_committal(&mut self) -> Option<FuelBlock> {
+    async fn next_fuel_block_for_committal(&mut self) -> Option<ValidatedFuelBlock> {
         self.rx_block.recv().await
     }
 }
@@ -34,7 +34,7 @@ where
     A: ports::l1::Contract + ports::l1::Api,
     Db: Storage,
 {
-    async fn submit_block(&self, fuel_block: FuelBlock) -> Result<()> {
+    async fn submit_block(&self, fuel_block: ValidatedFuelBlock) -> Result<()> {
         let submittal_height = self.l1.get_block_number().await?;
 
         let submission = BlockSubmission {
@@ -94,7 +94,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl Contract for MockL1 {
-        async fn submit(&self, block: FuelBlock) -> ports::l1::Result<()> {
+        async fn submit(&self, block: ValidatedFuelBlock) -> ports::l1::Result<()> {
             self.contract.submit(block).await
         }
         fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync> {
@@ -117,8 +117,8 @@ mod tests {
     async fn block_committer_will_submit_and_write_block() {
         // given
         let (tx, rx) = tokio::sync::mpsc::channel(10);
-        let block: FuelBlock = rand::thread_rng().gen();
-        let expected_height = block.height;
+        let block: ValidatedFuelBlock = rand::thread_rng().gen();
+        let expected_height = block.height();
         let process = PostgresProcess::shared().await.unwrap();
         let db = process.create_random_db().await.unwrap();
 
@@ -130,10 +130,10 @@ mod tests {
 
         // then
         let last_submission = db.submission_w_latest_block().await.unwrap().unwrap();
-        assert_eq!(expected_height, last_submission.block.height);
+        assert_eq!(expected_height, last_submission.block.height());
     }
 
-    fn given_l1_that_expects_submission(block: FuelBlock) -> MockL1 {
+    fn given_l1_that_expects_submission(block: ValidatedFuelBlock) -> MockL1 {
         let mut l1 = MockL1 {
             api: MockApi::new(),
             contract: MockContract::new(),
@@ -151,7 +151,7 @@ mod tests {
     }
 
     async fn spawn_committer_and_run_until_timeout<Db: Storage>(
-        rx: Receiver<FuelBlock>,
+        rx: Receiver<ValidatedFuelBlock>,
         mock_l1: MockL1,
         storage: Db,
     ) {

--- a/packages/services/src/commit_listener.rs
+++ b/packages/services/src/commit_listener.rs
@@ -57,7 +57,7 @@ where
 
         self.metrics
             .latest_committed_block
-            .set(i64::from(submission.block.height()));
+            .set(i64::from(submission.block_height));
 
         Ok(())
     }
@@ -145,7 +145,7 @@ mod tests {
             completed: false,
             ..rng.gen()
         };
-        let block_hash = submission.block.hash();
+        let block_hash = submission.block_hash;
 
         let contract = given_contract_with_events(vec![block_hash], submission.submittal_height);
 
@@ -172,8 +172,8 @@ mod tests {
             completed: false,
             ..rng.gen()
         };
-        let block_hash = submission.block.hash();
-        let fuel_block_height = submission.block.height();
+        let block_hash = submission.block_hash;
+        let fuel_block_height = submission.block_height;
 
         let contract = given_contract_with_events(vec![block_hash], submission.submittal_height);
 
@@ -210,8 +210,8 @@ mod tests {
         let block_missing_from_db: BlockSubmission = rng.gen();
         let incoming_block: BlockSubmission = rng.gen();
 
-        let missing_hash = block_missing_from_db.block.hash();
-        let incoming_hash = incoming_block.block.hash();
+        let missing_hash = block_missing_from_db.block_hash;
+        let incoming_hash = incoming_block.block_hash;
 
         let contract = given_contract_with_events(
             vec![missing_hash, incoming_hash],

--- a/packages/services/src/commit_listener.rs
+++ b/packages/services/src/commit_listener.rs
@@ -57,7 +57,7 @@ where
 
         self.metrics
             .latest_committed_block
-            .set(i64::from(submission.block.height));
+            .set(i64::from(submission.block.height()));
 
         Ok(())
     }
@@ -145,7 +145,7 @@ mod tests {
             completed: false,
             ..rng.gen()
         };
-        let block_hash = submission.block.hash;
+        let block_hash = submission.block.hash();
 
         let contract = given_contract_with_events(vec![block_hash], submission.submittal_height);
 
@@ -172,8 +172,8 @@ mod tests {
             completed: false,
             ..rng.gen()
         };
-        let block_hash = submission.block.hash;
-        let fuel_block_height = submission.block.height;
+        let block_hash = submission.block.hash();
+        let fuel_block_height = submission.block.height();
 
         let contract = given_contract_with_events(vec![block_hash], submission.submittal_height);
 
@@ -210,8 +210,8 @@ mod tests {
         let block_missing_from_db: BlockSubmission = rng.gen();
         let incoming_block: BlockSubmission = rng.gen();
 
-        let missing_hash = block_missing_from_db.block.hash;
-        let incoming_hash = incoming_block.block.hash;
+        let missing_hash = block_missing_from_db.block.hash();
+        let incoming_hash = incoming_block.block.hash();
 
         let contract = given_contract_with_events(
             vec![missing_hash, incoming_hash],

--- a/packages/services/src/lib.rs
+++ b/packages/services/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(unused_crate_dependencies)]
 mod block_committer;
 mod block_watcher;
 mod commit_listener;
@@ -36,6 +35,7 @@ impl From<ports::fuel::Error> for Error {
     fn from(value: ports::fuel::Error) -> Self {
         match value {
             ports::fuel::Error::Network(e) => Self::Network(e),
+            _ => Self::Other(value.to_string()),
         }
     }
 }

--- a/packages/services/src/lib.rs
+++ b/packages/services/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 mod block_committer;
 mod block_watcher;
 mod commit_listener;
@@ -16,26 +17,35 @@ pub use wallet_balance_tracker::WalletBalanceTracker;
 pub enum Error {
     #[error("{0}")]
     Other(String),
-    #[error("Network Error: {0}")]
+    #[error("Network error: {0}")]
     Network(String),
     #[error("Storage error: {0}")]
     Storage(String),
+    #[error("Block validation error: {0}")]
+    BlockValidation(String),
 }
 
 impl From<ports::l1::Error> for Error {
-    fn from(value: ports::l1::Error) -> Self {
-        match value {
+    fn from(error: ports::l1::Error) -> Self {
+        match error {
             ports::l1::Error::Network(e) => Self::Network(e),
-            _ => Self::Other(value.to_string()),
+            _ => Self::Other(error.to_string()),
         }
     }
 }
 
 impl From<ports::fuel::Error> for Error {
-    fn from(value: ports::fuel::Error) -> Self {
-        match value {
+    fn from(error: ports::fuel::Error) -> Self {
+        match error {
             ports::fuel::Error::Network(e) => Self::Network(e),
-            _ => Self::Other(value.to_string()),
+        }
+    }
+}
+
+impl From<validator::Error> for Error {
+    fn from(error: validator::Error) -> Self {
+        match error {
+            validator::Error::BlockValidation(e) => Self::BlockValidation(e),
         }
     }
 }

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -72,7 +72,7 @@ mod tests {
 
         let height = random_non_zero_height();
         let submission = given_incomplete_submission(height);
-        let block_hash = submission.block.hash();
+        let block_hash = submission.block_hash;
         db.insert(submission).await.unwrap();
 
         // when
@@ -90,7 +90,7 @@ mod tests {
 
         let height = random_non_zero_height();
         let submission = given_incomplete_submission(height);
-        let block_hash = submission.block.hash();
+        let block_hash = submission.block_hash;
 
         // when
         let result = db.set_submission_completed(block_hash).await;
@@ -106,7 +106,7 @@ mod tests {
 
     fn given_incomplete_submission(fuel_block_height: u32) -> BlockSubmission {
         let mut submission = rand::thread_rng().gen::<BlockSubmission>();
-        submission.block.set_height(fuel_block_height);
+        submission.block_height = fuel_block_height;
 
         submission
     }

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -72,7 +72,7 @@ mod tests {
 
         let height = random_non_zero_height();
         let submission = given_incomplete_submission(height);
-        let block_hash = submission.block.hash;
+        let block_hash = submission.block.hash();
         db.insert(submission).await.unwrap();
 
         // when
@@ -90,7 +90,7 @@ mod tests {
 
         let height = random_non_zero_height();
         let submission = given_incomplete_submission(height);
-        let block_hash = submission.block.hash;
+        let block_hash = submission.block.hash();
 
         // when
         let result = db.set_submission_completed(block_hash).await;
@@ -106,7 +106,7 @@ mod tests {
 
     fn given_incomplete_submission(fuel_block_height: u32) -> BlockSubmission {
         let mut submission = rand::thread_rng().gen::<BlockSubmission>();
-        submission.block.height = fuel_block_height;
+        submission.block.set_height(fuel_block_height);
 
         submission
     }

--- a/packages/storage/src/tables.rs
+++ b/packages/storage/src/tables.rs
@@ -1,4 +1,4 @@
-use ports::types::{BlockSubmission, FuelBlock};
+use ports::types::{BlockSubmission, ValidatedFuelBlock};
 
 #[derive(sqlx::FromRow)]
 pub struct L1FuelBlockSubmission {
@@ -35,7 +35,8 @@ impl TryFrom<L1FuelBlockSubmission> for BlockSubmission {
         };
 
         Ok(Self {
-            block: FuelBlock { hash, height },
+            // The block is taken from the DB so it should have been validated before storing
+            block: unsafe { ValidatedFuelBlock::new_unchecked(hash, height) },
             completed: value.completed,
             submittal_height,
         })
@@ -45,8 +46,8 @@ impl TryFrom<L1FuelBlockSubmission> for BlockSubmission {
 impl From<BlockSubmission> for L1FuelBlockSubmission {
     fn from(value: BlockSubmission) -> Self {
         Self {
-            fuel_block_hash: value.block.hash.to_vec(),
-            fuel_block_height: i64::from(value.block.height),
+            fuel_block_hash: value.block.hash().to_vec(),
+            fuel_block_height: i64::from(value.block.height()),
             completed: value.completed,
             submittal_height: value.submittal_height.into(),
         }

--- a/packages/storage/src/tables.rs
+++ b/packages/storage/src/tables.rs
@@ -1,4 +1,4 @@
-use ports::types::{BlockSubmission, ValidatedFuelBlock};
+use ports::types::BlockSubmission;
 
 #[derive(sqlx::FromRow)]
 pub struct L1FuelBlockSubmission {
@@ -18,11 +18,11 @@ impl TryFrom<L1FuelBlockSubmission> for BlockSubmission {
                 return Err(Self::Error::Conversion(format!($msg, $($args),*)));
             };
         }
-        let Ok(hash) = block_hash.try_into() else {
+        let Ok(block_hash) = block_hash.try_into() else {
             bail!("Expected 32 bytes for `fuel_block_hash`, but got: {block_hash:?} from db",);
         };
 
-        let Ok(height) = value.fuel_block_height.try_into() else {
+        let Ok(block_height) = value.fuel_block_height.try_into() else {
             bail!(
                 "`fuel_block_height` as read from the db cannot fit in a `u32` as expected. Got: {:?} from db",
                 value.fuel_block_height
@@ -35,8 +35,8 @@ impl TryFrom<L1FuelBlockSubmission> for BlockSubmission {
         };
 
         Ok(Self {
-            // The block is taken from the DB so it should have been validated before storing
-            block: unsafe { ValidatedFuelBlock::new_unchecked(hash, height) },
+            block_hash,
+            block_height,
             completed: value.completed,
             submittal_height,
         })
@@ -46,8 +46,8 @@ impl TryFrom<L1FuelBlockSubmission> for BlockSubmission {
 impl From<BlockSubmission> for L1FuelBlockSubmission {
     fn from(value: BlockSubmission) -> Self {
         Self {
-            fuel_block_hash: value.block.hash().to_vec(),
-            fuel_block_height: i64::from(value.block.height()),
+            fuel_block_hash: value.block_hash.to_vec(),
+            fuel_block_height: i64::from(value.block_height),
             completed: value.completed,
             submittal_height: value.submittal_height.into(),
         }

--- a/packages/validator/Cargo.toml
+++ b/packages/validator/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "validator"
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+publish = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+fuel-crypto = { workspace = true, optional = true }
+fuel-core-client = { workspace = true }
+mockall = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tai64 = { workspace = true }
+
+[features]
+validator = ["dep:fuel-crypto"]
+test-helpers = ["validator", "dep:mockall", "dep:rand"]

--- a/packages/validator/src/block.rs
+++ b/packages/validator/src/block.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct ValidatedFuelBlock {
+    pub(crate) hash: [u8; 32],
+    pub(crate) height: u32,
+}
+
+impl ValidatedFuelBlock {
+    pub fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[cfg(feature = "test-helpers")]
+    pub fn new(hash: [u8; 32], height: u32) -> Self {
+        Self { hash, height }
+    }
+}
+
+impl std::fmt::Debug for ValidatedFuelBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hash = self.hash.map(|byte| format!("{byte:02x?}")).join("");
+        f.debug_struct("ValidatedFuelBlock")
+            .field("hash", &hash)
+            .field("height", &self.height)
+            .finish()
+    }
+}
+
+#[cfg(feature = "test-helpers")]
+impl From<fuel_core_client::client::types::block::Block> for ValidatedFuelBlock {
+    fn from(block: fuel_core_client::client::types::block::Block) -> Self {
+        Self {
+            hash: *block.id,
+            height: block.header.height,
+        }
+    }
+}
+
+#[cfg(feature = "test-helpers")]
+impl rand::distributions::Distribution<ValidatedFuelBlock> for rand::distributions::Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> ValidatedFuelBlock {
+        ValidatedFuelBlock {
+            hash: rng.gen(),
+            height: rng.gen(),
+        }
+    }
+}

--- a/packages/validator/src/lib.rs
+++ b/packages/validator/src/lib.rs
@@ -1,0 +1,23 @@
+#![deny(unused_crate_dependencies)]
+pub mod block;
+#[cfg(feature = "validator")]
+mod validator;
+
+use fuel_core_client::client::types::block::Block as FuelBlock;
+#[cfg(feature = "validator")]
+pub use validator::*;
+
+use crate::block::ValidatedFuelBlock;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    BlockValidation(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg_attr(feature = "test-helpers", mockall::automock)]
+pub trait Validator: Send + Sync {
+    fn validate(&self, fuel_block: &FuelBlock) -> Result<ValidatedFuelBlock>;
+}

--- a/packages/validator/src/validator.rs
+++ b/packages/validator/src/validator.rs
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "does not match calculated block id")]
-    fn validate_block_id_mismach() {
+    fn validate_block_id_mismatch() {
         let secret_key = given_secret_key();
         let mut fuel_block = given_a_block(Some(secret_key));
         fuel_block.header.height = 42; // Change a value to get a different block id

--- a/packages/validator/src/validator.rs
+++ b/packages/validator/src/validator.rs
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "does not match calculated block id")]
-    fn validate_block_id_mistmach() {
+    fn validate_block_id_mismach() {
         let secret_key = given_secret_key();
         let mut fuel_block = given_a_block(Some(secret_key));
         fuel_block.header.height = 42; // Change a value to get a different block id


### PR DESCRIPTION
closes: https://github.com/FuelLabs/fuel-block-committer/issues/57

This PR introduces a new `validator` crate which holds a `BlockValidator` struct that can validate blocks coming from the fuel network. Once the `block_watcher` receives a new block it is validated by the `BlockValidator` and a new `ValidatedFuelBlock` is then propagated throughout the block committer.