### PR TITLE
Pull commit interval config from contract

### DIFF
--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -1,4 +1,4 @@
-use std::{net::Ipv4Addr, num::NonZeroU32, path::PathBuf, str::FromStr, time::Duration};
+use std::{net::Ipv4Addr, path::PathBuf, str::FromStr, time::Duration};
 
 use clap::{command, Parser};
 use eth::{Address, Chain};
@@ -34,35 +34,6 @@ pub struct EthConfig {
     pub chain_id: Chain,
     /// Ethereum address of the fuel chain state contract.
     pub state_contract_address: Address,
-    /// The number of fuel blocks between ethereum commits. If set to 1, then every block should be pushed to Ethereum.
-    #[serde(
-        default = "default_commit_interval",
-        deserialize_with = "deserialize_commit_interval"
-    )]
-    pub commit_interval: NonZeroU32,
-}
-impl EthConfig {
-    pub fn set_commit_interval(&mut self, commit_interval: NonZeroU32) {
-        self.commit_interval = commit_interval;
-    }
-}
-
-impl Config {
-    pub fn set_commit_interval(&mut self, commit_interval: NonZeroU32) {
-        self.eth.set_commit_interval(commit_interval);
-    }
-}
-
-fn default_commit_interval() -> NonZeroU32 {
-    NonZeroU32::new(1).unwrap() // Default to 1 if not provided
-}
-
-fn deserialize_commit_interval<'de, D>(deserializer: D) -> Result<NonZeroU32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    Option::<NonZeroU32>::deserialize(deserializer)
-        .map(|opt| opt.unwrap_or_else(default_commit_interval))
 }
 
 fn parse_chain_id<'de, D>(deserializer: D) -> Result<Chain, D::Error>

--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -35,7 +35,34 @@ pub struct EthConfig {
     /// Ethereum address of the fuel chain state contract.
     pub state_contract_address: Address,
     /// The number of fuel blocks between ethereum commits. If set to 1, then every block should be pushed to Ethereum.
+    #[serde(
+        default = "default_commit_interval",
+        deserialize_with = "deserialize_commit_interval"
+    )]
     pub commit_interval: NonZeroU32,
+}
+impl EthConfig {
+    pub fn set_commit_interval(&mut self, commit_interval: NonZeroU32) {
+        self.commit_interval = commit_interval;
+    }
+}
+
+impl Config {
+    pub fn set_commit_interval(&mut self, commit_interval: NonZeroU32) {
+        self.eth.set_commit_interval(commit_interval);
+    }
+}
+
+fn default_commit_interval() -> NonZeroU32 {
+    NonZeroU32::new(1).unwrap() // Default to 1 if not provided
+}
+
+fn deserialize_commit_interval<'de, D>(deserializer: D) -> Result<NonZeroU32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<NonZeroU32>::deserialize(deserializer)
+        .map(|opt| opt.unwrap_or_else(default_commit_interval))
 }
 
 fn parse_chain_id<'de, D>(deserializer: D) -> Result<Chain, D::Error>

--- a/committer/src/main.rs
+++ b/committer/src/main.rs
@@ -26,7 +26,7 @@ pub type Validator = validator::BlockValidator;
 async fn main() -> Result<()> {
     setup_logger();
 
-    let mut config = config::parse()?;
+    let config = config::parse()?;
 
     let storage = setup_storage(&config).await?;
 
@@ -38,9 +38,10 @@ async fn main() -> Result<()> {
     let (ethereum_rpc, eth_health_check) =
         create_l1_adapter(&config, &internal_config, &metrics_registry).await?;
 
-    config.set_commit_interval(ethereum_rpc.commit_interval()?);
+    let commit_interval = ethereum_rpc.commit_interval();
 
     let (rx_fuel_block, block_watcher_handle, fuel_health_check) = spawn_block_watcher(
+        commit_interval,
         &config,
         &internal_config,
         storage.clone(),

--- a/committer/src/setup.rs
+++ b/committer/src/setup.rs
@@ -105,7 +105,6 @@ pub async fn create_l1_adapter(
         config.eth.chain_id,
         config.eth.state_contract_address,
         &config.eth.wallet_key,
-        config.eth.commit_interval,
         internal_config.eth_errors_before_unhealthy,
     )
     .await?;

--- a/configurations/development/config.toml
+++ b/configurations/development/config.toml
@@ -2,7 +2,6 @@
 wallet_key = "0x9e56ccf010fa4073274b8177ccaad46fbaf286645310d03ac9bb6afa922a7c36"
 chain_id = "hardhat"
 state_contract_address = "0xdAad669b06d79Cb48C8cfef789972436dBe6F24d"
-commit_interval = 3
 rpc = "ws://localhost:8089"
 
 [fuel]

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use anyhow::{anyhow, Result};
     use eth::{Chain, WebsocketClient};
     use fuel::HttpClient;
     use ports::fuel::{Api, FuelPublicKey};
+    use ports::l1::Contract;
+    use std::time::Duration;
     use validator::{BlockValidator, Validator};
 
     const FUEL_NODE_PORT: u16 = 4000;
@@ -24,7 +24,9 @@ mod tests {
         )
         .await?;
 
-        provider.produce_blocks(3).await?;
+        provider
+            .produce_blocks(fuel_contract.commit_interval().into())
+            .await?;
 
         // time enough to fwd the block to ethereum and for the TIME_TO_FINALIZE (1s) to elapse
         tokio::time::sleep(Duration::from_secs(5)).await;

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -20,7 +20,6 @@ mod tests {
             Chain::AnvilHardhat,
             "0xdAad669b06d79Cb48C8cfef789972436dBe6F24d".parse()?,
             "0x9e56ccf010fa4073274b8177ccaad46fbaf286645310d03ac9bb6afa922a7c36",
-            3.try_into()?,
             10,
         )
         .await?;

--- a/eth_node/Dockerfile
+++ b/eth_node/Dockerfile
@@ -6,7 +6,6 @@ RUN git clone --no-checkout https://github.com/FuelLabs/fuel-bridge \
   && cd packages/solidity-contracts \
   && rm -rf deploy deployments exports test \
   && cd contracts \
-  && sed 's/\(BLOCKS_PER_COMMIT_INTERVAL\) = 10800/\1 = 3/g' -i ./fuelchain/FuelChainState.sol \
   && sed 's/\(TIME_TO_FINALIZE\) = 10800/\1 = 1/g' -i ./fuelchain/FuelChainState.sol
 
 FROM alpine:3.19.1

--- a/packages/eth/src/lib.rs
+++ b/packages/eth/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unused_crate_dependencies)]
 
+use std::num::NonZeroU32;
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -28,8 +29,8 @@ impl Contract for WebsocketClient {
         Box::new(self.event_streamer(height.into()))
     }
 
-    fn commit_interval(&self) -> Result<std::num::NonZeroU32> {
-        Ok(self.commit_interval()?)
+    fn commit_interval(&self) -> NonZeroU32 {
+        self.commit_interval()
     }
 }
 

--- a/packages/eth/src/lib.rs
+++ b/packages/eth/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unused_crate_dependencies)]
+
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -25,6 +26,10 @@ impl Contract for WebsocketClient {
 
     fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync> {
         Box::new(self.event_streamer(height.into()))
+    }
+
+    fn commit_interval(&self) -> Result<std::num::NonZeroU32> {
+        Ok(self.commit_interval()?)
     }
 }
 

--- a/packages/eth/src/websocket.rs
+++ b/packages/eth/src/websocket.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU32;
-
 use ::metrics::{prometheus::core::Collector, HealthChecker, RegistersMetrics};
 use ethers::types::{Address, Chain};
 use ports::{
@@ -29,12 +27,9 @@ impl WebsocketClient {
         chain_id: Chain,
         contract_address: Address,
         wallet_key: &str,
-        commit_interval: NonZeroU32,
         unhealthy_after_n_errors: usize,
     ) -> ports::l1::Result<Self> {
-        let provider =
-            WsConnection::connect(url, chain_id, contract_address, wallet_key, commit_interval)
-                .await?;
+        let provider = WsConnection::connect(url, chain_id, contract_address, wallet_key).await?;
 
         Ok(Self {
             inner: HealthTrackingMiddleware::new(provider, unhealthy_after_n_errors),
@@ -52,6 +47,10 @@ impl WebsocketClient {
 
     pub(crate) async fn submit(&self, block: ValidatedFuelBlock) -> Result<()> {
         Ok(self.inner.submit(block).await?)
+    }
+
+    pub(crate) fn commit_interval(&self) -> Result<std::num::NonZeroU32> {
+        Ok(self.inner.commit_interval()?)
     }
 
     pub(crate) async fn get_block_number(&self) -> Result<u64> {

--- a/packages/eth/src/websocket.rs
+++ b/packages/eth/src/websocket.rs
@@ -4,6 +4,7 @@ use ports::{
     l1::Result,
     types::{ValidatedFuelBlock, U256},
 };
+use std::num::NonZeroU32;
 use url::Url;
 
 pub use self::event_streamer::EthEventStreamer;
@@ -49,8 +50,8 @@ impl WebsocketClient {
         Ok(self.inner.submit(block).await?)
     }
 
-    pub(crate) fn commit_interval(&self) -> Result<std::num::NonZeroU32> {
-        Ok(self.inner.commit_interval()?)
+    pub(crate) fn commit_interval(&self) -> NonZeroU32 {
+        self.inner.commit_interval()
     }
 
     pub(crate) async fn get_block_number(&self) -> Result<u64> {

--- a/packages/eth/src/websocket/connection.rs
+++ b/packages/eth/src/websocket/connection.rs
@@ -61,8 +61,8 @@ impl EthApi for WsConnection {
         Ok(self.provider.get_balance(address, None).await?)
     }
 
-    fn commit_interval(&self) -> Result<NonZeroU32> {
-        Ok(self.commit_interval)
+    fn commit_interval(&self) -> NonZeroU32 {
+        self.commit_interval
     }
 
     fn event_streamer(&self, eth_block_height: u64) -> EthEventStreamer {
@@ -115,8 +115,9 @@ impl WsConnection {
         let commit_interval = u32::try_from(interval_u256)
             .map_err(|e| Error::Other(e.to_string()))
             .and_then(|value| {
-                NonZeroU32::new(value)
-                    .ok_or_else(|| Error::Other("l1 contract reported a commit interval of 0"))
+                NonZeroU32::new(value).ok_or_else(|| {
+                    Error::Other("l1 contract reported a commit interval of 0".to_string())
+                })
             })?;
 
         Ok(Self {

--- a/packages/eth/src/websocket/connection.rs
+++ b/packages/eth/src/websocket/connection.rs
@@ -116,7 +116,7 @@ impl WsConnection {
             .map_err(|e| Error::Other(e.to_string()))
             .and_then(|value| {
                 NonZeroU32::new(value)
-                    .ok_or_else(|| Error::Other("Value cannot be zero".to_string()))
+                    .ok_or_else(|| Error::Other("l1 contract reported a commit interval of 0"))
             })?;
 
         Ok(Self {

--- a/packages/eth/src/websocket/health_tracking_middleware.rs
+++ b/packages/eth/src/websocket/health_tracking_middleware.rs
@@ -18,7 +18,7 @@ pub trait EthApi {
     async fn submit(&self, block: ValidatedFuelBlock) -> Result<()>;
     async fn get_block_number(&self) -> Result<u64>;
     async fn balance(&self) -> Result<U256>;
-    fn commit_interval(&self) -> Result<NonZeroU32>;
+    fn commit_interval(&self) -> NonZeroU32;
     fn event_streamer(&self, eth_block_height: u64) -> EthEventStreamer;
     #[cfg(feature = "test-helpers")]
     async fn finalized(&self, block: ValidatedFuelBlock) -> Result<bool>;
@@ -94,7 +94,7 @@ where
         response
     }
 
-    fn commit_interval(&self) -> Result<NonZeroU32> {
+    fn commit_interval(&self) -> NonZeroU32 {
         self.adapter.commit_interval()
     }
 

--- a/packages/eth/src/websocket/health_tracking_middleware.rs
+++ b/packages/eth/src/websocket/health_tracking_middleware.rs
@@ -1,6 +1,9 @@
 use ::metrics::{
     prometheus::core::Collector, ConnectionHealthTracker, HealthChecker, RegistersMetrics,
 };
+
+use std::num::NonZeroU32;
+
 use ports::types::{ValidatedFuelBlock, U256};
 
 use crate::{
@@ -15,6 +18,7 @@ pub trait EthApi {
     async fn submit(&self, block: ValidatedFuelBlock) -> Result<()>;
     async fn get_block_number(&self) -> Result<u64>;
     async fn balance(&self) -> Result<U256>;
+    fn commit_interval(&self) -> Result<NonZeroU32>;
     fn event_streamer(&self, eth_block_height: u64) -> EthEventStreamer;
     #[cfg(feature = "test-helpers")]
     async fn finalized(&self, block: ValidatedFuelBlock) -> Result<bool>;
@@ -88,6 +92,10 @@ where
         let response = self.adapter.balance().await;
         self.note_network_status(&response);
         response
+    }
+
+    fn commit_interval(&self) -> Result<NonZeroU32> {
+        self.adapter.commit_interval()
     }
 
     #[cfg(feature = "test-helpers")]

--- a/packages/ports/src/ports/l1.rs
+++ b/packages/ports/src/ports/l1.rs
@@ -25,6 +25,7 @@ impl From<InvalidL1Height> for Error {
 pub trait Contract: Send + Sync {
     async fn submit(&self, block: ValidatedFuelBlock) -> Result<()>;
     fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync>;
+    fn commit_interval(&self) -> Result<std::num::NonZeroU32>;
 }
 
 #[cfg_attr(feature = "test-helpers", mockall::automock)]

--- a/packages/ports/src/ports/l1.rs
+++ b/packages/ports/src/ports/l1.rs
@@ -25,7 +25,7 @@ impl From<InvalidL1Height> for Error {
 pub trait Contract: Send + Sync {
     async fn submit(&self, block: ValidatedFuelBlock) -> Result<()>;
     fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync>;
-    fn commit_interval(&self) -> Result<std::num::NonZeroU32>;
+    fn commit_interval(&self) -> std::num::NonZeroU32;
 }
 
 #[cfg_attr(feature = "test-helpers", mockall::automock)]

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -103,7 +103,7 @@ mod tests {
             self.contract.event_streamer(height)
         }
 
-        fn commit_interval(&self) -> ports::l1::Result<NonZeroU32> {
+        fn commit_interval(&self) -> NonZeroU32 {
             self.contract.commit_interval()
         }
     }

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -76,6 +76,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
     use std::time::Duration;
 
     use mockall::predicate;
@@ -100,6 +101,10 @@ mod tests {
         }
         fn event_streamer(&self, height: L1Height) -> Box<dyn EventStreamer + Send + Sync> {
             self.contract.event_streamer(height)
+        }
+
+        fn commit_interval(&self) -> ports::l1::Result<NonZeroU32> {
+            self.contract.commit_interval()
         }
     }
 


### PR DESCRIPTION
I've removed the commit_interval from our configuration. Instead, the committee will now use the interval set in the state contract directly.

- Added `BLOCKS_PER_COMMIT_INTERVAL() external view returns (uint256)` function to retrieve the commit interval from the contract.
- Extended the Contract trait with fn `commit_interval(&self) -> Result<std::num::NonZeroU32>`.
- Updated code to utilize the new `commit_interval` function.
- Added setters to the `Config` structure.