### PR TITLE
refactor: add context to errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   verify-rust-version:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       # Ensure CI is using the same minimum toolchain specified in fuels Cargo.toml
@@ -49,7 +49,7 @@ jobs:
   cargo-verifications:
     needs:
       - verify-rust-version
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
         run: ./run_tests.sh
 
   publish-crates-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
       - publish-crates-check
     # Only do this job if publishing a release
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
@@ -125,7 +125,7 @@ jobs:
   publish-docker-image:
     needs:
       - cargo-verifications
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/committer/src/main.rs
+++ b/committer/src/main.rs
@@ -5,7 +5,7 @@ mod errors;
 mod setup;
 
 use api::launch_api_server;
-use errors::Result;
+use errors::{Result, WithContext};
 use metrics::prometheus::Registry;
 use tokio_util::sync::CancellationToken;
 
@@ -21,10 +21,14 @@ pub type Validator = validator::BlockValidator;
 async fn main() -> Result<()> {
     setup::logger();
 
-    let config = config::parse()?;
-    config.validate()?;
+    let config = config::parse().with_context(|| "failed to parse config")?;
+    config
+        .validate()
+        .with_context(|| "config validation failed")?;
 
-    let storage = setup::storage(&config).await?;
+    let storage = setup::storage(&config)
+        .await
+        .with_context(|| "failed to connect to database")?;
 
     let internal_config = config::Internal::default();
     let cancel_token = CancellationToken::new();
@@ -35,7 +39,9 @@ async fn main() -> Result<()> {
         setup::fuel_adapter(&config, &internal_config, &metrics_registry);
 
     let (ethereum_rpc, eth_health_check) =
-        setup::l1_adapter(&config, &internal_config, &metrics_registry).await?;
+        setup::l1_adapter(&config, &internal_config, &metrics_registry)
+            .await
+            .with_context(|| "could not setup l1 adapter")?;
 
     let commit_interval = ethereum_rpc.commit_interval();
 
@@ -104,7 +110,8 @@ async fn main() -> Result<()> {
         fuel_health_check,
         eth_health_check,
     )
-    .await?;
+    .await
+    .with_context(|| "api server")?;
 
     shut_down(cancel_token, handles, storage).await
 }


### PR DESCRIPTION
The top level errors don't have context. Difficult to tell what failed. 

The runners are fine, they are given context by the runnable.