### PR TITLE
feat(compression): include da compressed blocks into the block importer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   DASEL_VERSION: https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64
   RUST_VERSION: 1.79
-  FUEL_CORE_VERSION: 0.36.0
+  FUEL_CORE_VERSION: 0.38.0
   IMAGE_NAME: ${{ github.repository }}
   REPO_NAME: ${{ github.event.repository.name }}
   AWS_ROLE_ARN: arn:aws:iam::024848458133:role/github_oidc_FuelLabs_fuel-block-committer

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,6 @@ dependencies = [
  "cynic",
  "delegate",
  "fuel-core-client",
- "fuel-core-types",
  "futures",
  "metrics",
  "ports",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ dependencies = [
  "cynic",
  "delegate",
  "fuel-core-client",
+ "fuel-core-types",
  "futures",
  "metrics",
  "ports",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,7 @@ dependencies = [
  "async-trait",
  "delegate",
  "fuel-core-client",
+ "fuel-core-types",
  "futures",
  "itertools 0.13.0",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,9 +2677,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eventsource-client"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
+checksum = "43ddc25e1ad2cc0106d5e2d967397b4fb2068a66677ee9b0eea4600e5cfe8fb4"
 dependencies = [
  "futures",
  "hyper 0.14.30",
@@ -2823,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b83807968cd62babe6cd70c94b76c86f302c8573da18b3c69135688eceecd"
+checksum = "5f325971bf9047ec70004f80a989e03456316bc19cbef3ff3a39a38b192ab56e"
 dependencies = [
  "bitflags 2.6.0",
  "fuel-types",
@@ -2861,10 +2861,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-core-chain-config"
-version = "0.36.0"
+name = "fuel-compression"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4c5a71702426b8354bff2010131c0abb4a4f0b608cc7a6dfd72f9e785ba478"
+checksum = "24e42841f56f76ed759b3f516e5188d5c42de47015bee951651660c13b6dfa6c"
+dependencies = [
+ "fuel-derive",
+ "fuel-types",
+ "serde",
+]
+
+[[package]]
+name = "fuel-core-chain-config"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ea79e0a35e9d69e16f7bad306822a49900fb05753c12b3ac987b5e5944a451"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2882,11 +2893,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5770dbda6220e641eb57ee204dd5914fa15170afe3009473f57cdf15e2339fd8"
+checksum = "6efc202b5e2b6130e1523c2f147b7fae5e86adca17f2057d033ec514eb4b040e"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "cynic",
  "derive_more 0.99.18",
  "eventsource-client",
@@ -2906,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1daa7422e48120b1623b53fe1a1152d11314f30fb290a73dc80f7e128c1f9014"
+checksum = "0d8301b364dc298d3ad9094a8e8c3d202b2e8c76df27e087d625fe304c9878eb"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
@@ -2928,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa1c54f09cc7c29a11ca1129f73105745f8374a192e3e24040c10822871d83f"
+checksum = "f0941706822b301200d3c71d6c27e90480bfcb13a11be89e2e3fb74e7dd1cb94"
 dependencies = [
  "anyhow",
  "bs58",
@@ -2946,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a4ca62d0a8a361b66a6eab3456285883d0aa92c407e249fc76f195c332fbb2"
+checksum = "65e318850ca64890ff123a99b6b866954ef49da94ab9bc6827cf6ee045568585"
 dependencies = [
  "coins-bip32 0.8.7",
  "coins-bip39 0.8.7",
@@ -2967,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca99d9c264fec231a01e55bbdb6adb3080266dc44c4cc88de870b089ee2a015"
+checksum = "ab0bc46a3552964bae5169e79b383761a54bd115ea66951a1a7a229edcefa55a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f3c08f22f7c24170a4ac255e7dfe52d52ae2e85c4a8e26ed6df4f1bd380210"
+checksum = "c79eca6a452311c70978a5df796c0f99f27e474b69719e0db4c1d82e68800d07"
 dependencies = [
  "derive_more 0.99.18",
  "digest 0.10.7",
@@ -2994,20 +3006,21 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d676ea5d926bf90c8ea442e5f6fc23c0e86c2e4d663f303842b4afe5b7928084"
+checksum = "2d0c46b5d76b3e11197bd31e036cd8b1cb46c4d822cacc48836638080c6d2b76"
 
 [[package]]
 name = "fuel-tx"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86158d08fe2a936ac765a1e2cb9bf60be704203b3085882e7cc6cd4c48de38ef"
+checksum = "6723bb8710ba2b70516ac94d34459593225870c937670fb3afaf82e0354667ac"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
  "derive_more 0.99.18",
  "fuel-asm",
+ "fuel-compression",
  "fuel-crypto",
  "fuel-merkle",
  "fuel-types",
@@ -3016,16 +3029,15 @@ dependencies = [
  "postcard",
  "rand",
  "serde",
- "serde_json",
  "strum 0.24.1",
  "strum_macros 0.24.3",
 ]
 
 [[package]]
 name = "fuel-types"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b4430c6a20669fffd8f2c17d2be6809a356f623243a78b5eedf8ba7897c036"
+checksum = "982265415a99b5bd6277bc24194a233bb2e18764df11c937b3dbb11a02c9e545"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -3035,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.57.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b04a4e971d58b3662ff8b84b3176094e25f4b372728a13ea903fdf79c7e426"
+checksum = "54b5362d7d072c72eec20581f67fc5400090c356a7f3ae77c79880b3b177b667"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3047,6 +3059,7 @@ dependencies = [
  "derive_more 0.99.18",
  "ethnum",
  "fuel-asm",
+ "fuel-compression",
  "fuel-crypto",
  "fuel-merkle",
  "fuel-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ config = { version = "0.14", default-features = false }
 delegate = { version = "0.13", default-features = false }
 flate2 = { version = "1.0", default-features = false }
 fs_extra = { version = "1.3", default-features = false }
-fuel-core-chain-config = { version = "0.36", default-features = false }
-fuel-core-client = { version = "0.36", default-features = false }
-fuel-core-types = { version = "0.36", default-features = false }
-fuel-crypto = { version = "0.57", default-features = false }
+fuel-core-chain-config = { version = "0.38.0", default-features = false }
+fuel-core-client = { version = "0.38.0", default-features = false }
+fuel-core-types = { version = "0.38.0", default-features = false, features = ["da-compression"] }
+fuel-crypto = { version = "0.58.2", default-features = false }
 futures = { version = "0.3", default-features = false }
 hex = { version = "0.4", default-features = false }
 humantime = { version = "2.1", default-features = false }

--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -1,9 +1,4 @@
-use std::{
-    net::Ipv4Addr,
-    num::{NonZeroU32, NonZeroUsize},
-    str::FromStr,
-    time::Duration,
-};
+use std::{net::Ipv4Addr, num::NonZeroUsize, str::FromStr, time::Duration};
 
 use clap::{command, Parser};
 use eth::Address;
@@ -53,7 +48,6 @@ pub struct Fuel {
     pub graphql_endpoint: Url,
     /// Block producer address
     pub block_producer_address: ports::fuel::FuelBytes32,
-    pub max_full_blocks_per_request: NonZeroU32,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/committer/src/setup.rs
+++ b/committer/src/setup.rs
@@ -239,7 +239,6 @@ pub fn fuel_adapter(
     let fuel_adapter = FuelApi::new(
         &config.fuel.graphql_endpoint,
         internal_config.fuel_errors_before_unhealthy,
-        config.fuel.max_full_blocks_per_request,
     );
     fuel_adapter.register_metrics(registry);
 

--- a/e2e/src/fuel_node.rs
+++ b/e2e/src/fuel_node.rs
@@ -108,6 +108,8 @@ impl FuelNode {
             .arg("--debug")
             .arg(format!("--native-executor-version={executor_version}"))
             .env("CONSENSUS_KEY_SECRET", format!("{}", secret_key))
+            .arg("--da-compression")
+            .arg("1hr")
             .kill_on_drop(true)
             .stdin(std::process::Stdio::null());
 

--- a/e2e/src/fuel_node.rs
+++ b/e2e/src/fuel_node.rs
@@ -144,7 +144,7 @@ impl FuelNode {
 
 impl FuelNodeProcess {
     pub fn client(&self) -> HttpClient {
-        HttpClient::new(&self.url, 5, 100.try_into().unwrap())
+        HttpClient::new(&self.url, 5)
     }
 
     pub async fn produce_transactions(&self, amount: usize) -> anyhow::Result<()> {

--- a/e2e/src/whole_stack.rs
+++ b/e2e/src/whole_stack.rs
@@ -38,9 +38,7 @@ impl FuelNodeType {
     pub fn client(&self) -> HttpClient {
         match self {
             FuelNodeType::Local(fuel_node) => fuel_node.client(),
-            FuelNodeType::Testnet { .. } => {
-                HttpClient::new(&self.url(), 10, 100.try_into().unwrap())
-            }
+            FuelNodeType::Testnet { .. } => HttpClient::new(&self.url(), 10),
         }
     }
 }

--- a/packages/fuel/Cargo.toml
+++ b/packages/fuel/Cargo.toml
@@ -14,7 +14,6 @@ build = "build.rs"
 cynic = { version = "2.2", features = ["http-reqwest"] }
 delegate = { workspace = true }
 fuel-core-client = { workspace = true, features = ["subscriptions"] }
-fuel-core-types = { workspace = true }
 futures = { workspace = true }
 metrics = { workspace = true }
 ports = { workspace = true, features = ["fuel"] }

--- a/packages/fuel/Cargo.toml
+++ b/packages/fuel/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 cynic = { version = "2.2", features = ["http-reqwest"] }
 delegate = { workspace = true }
 fuel-core-client = { workspace = true, features = ["subscriptions"] }
+fuel-core-types = { workspace = true, optional = true }
 futures = { workspace = true }
 metrics = { workspace = true }
 ports = { workspace = true, features = ["fuel"] }
@@ -22,7 +23,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }
-fuel-core-types = { workspace = true, optional = true }
 
 [build-dependencies]
 fuel-core-client = { workspace = true }

--- a/packages/fuel/Cargo.toml
+++ b/packages/fuel/Cargo.toml
@@ -22,9 +22,10 @@ url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }
+fuel-core-types = { workspace = true, optional = true }
 
 [build-dependencies]
 fuel-core-client = { workspace = true }
 
 [features]
-test-helpers = []
+test-helpers = ["dep:fuel-core-types"]

--- a/packages/fuel/src/client.rs
+++ b/packages/fuel/src/client.rs
@@ -159,7 +159,7 @@ impl HttpClient {
                 .expect("should be parseable");
             if let Ok(Some(response)) = self
                 .client
-                .da_compressed_block_with_id(query_block_height.into())
+                .da_compressed_block_with_id(query_block_height)
                 .await
             {
                 let compressed_block = MaybeCompressedFuelBlock::Compressed(CompressedBlock::new(
@@ -191,7 +191,7 @@ impl HttpClient {
                     .consume(response)
                     .into_iter()
                     .map(ports::fuel::FullFuelBlock::try_from)
-                    .map(|full_block| full_block.map(MaybeCompressedFuelBlock::Uncompressed))
+                    .map(|full_block| full_block.map(MaybeCompressedFuelBlock::from))
                     .collect::<Result<_>>()?;
 
                 if results.is_empty() {

--- a/packages/fuel/src/client.rs
+++ b/packages/fuel/src/client.rs
@@ -164,7 +164,7 @@ impl HttpClient {
             {
                 let compressed_block = MaybeCompressedFuelBlock::Compressed(CompressedBlock::new(
                     query_block_height,
-                    response.block.id.into(),
+                    response.block_id.into(),
                     response.da_compressed_block.bytes.into(),
                 ));
 

--- a/packages/fuel/src/client/block_ext.rs
+++ b/packages/fuel/src/client/block_ext.rs
@@ -1,5 +1,4 @@
 use cynic::QueryBuilder;
-use fuel_core_client::client::schema::block::Block;
 use fuel_core_client::client::schema::da_compressed::DaCompressedBlock;
 use fuel_core_client::client::schema::U32;
 use fuel_core_client::client::{

--- a/packages/fuel/src/client/block_ext.rs
+++ b/packages/fuel/src/client/block_ext.rs
@@ -74,12 +74,18 @@ pub struct DaCompressedBlockWithBlockIdByHeightQuery {
     #[arguments(height: $height)]
     pub da_compressed_block: Option<DaCompressedBlock>,
     #[arguments(height: $block_height)]
-    pub block: Option<Block>,
+    pub block: Option<OnlyBlockId>,
 }
 
 pub struct DaCompressedBlockWithBlockId {
     pub da_compressed_block: DaCompressedBlock,
-    pub block: Block,
+    pub block_id: BlockId,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./target/schema.sdl", graphql_type = "Block")]
+pub struct OnlyBlockId {
+    pub id: BlockId,
 }
 
 impl TryFrom<FullBlock> for ports::fuel::FullFuelBlock {
@@ -171,7 +177,7 @@ impl ClientExt for FuelClient {
         ) {
             Ok(Some(DaCompressedBlockWithBlockId {
                 da_compressed_block: da_compressed,
-                block,
+                block_id: block.id,
             }))
         } else {
             Ok(None)

--- a/packages/fuel/src/client/block_ext.rs
+++ b/packages/fuel/src/client/block_ext.rs
@@ -51,7 +51,17 @@ pub struct FullBlock {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct DaCompressedBlockWithBlockIdByHeightArgs {
-    pub height: U32,
+    height: U32,
+    block_height: Option<U32>,
+}
+
+impl DaCompressedBlockWithBlockIdByHeightArgs {
+    pub fn new(height: u32) -> Self {
+        Self {
+            height: height.into(),
+            block_height: Some(height.into()),
+        }
+    }
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -63,6 +73,7 @@ pub struct DaCompressedBlockWithBlockIdByHeightArgs {
 pub struct DaCompressedBlockWithBlockIdByHeightQuery {
     #[arguments(height: $height)]
     pub da_compressed_block: Option<DaCompressedBlock>,
+    #[arguments(height: $block_height)]
     pub block: Option<Block>,
 }
 
@@ -150,9 +161,7 @@ impl ClientExt for FuelClient {
         height: u32,
     ) -> std::io::Result<Option<DaCompressedBlockWithBlockId>> {
         let query = DaCompressedBlockWithBlockIdByHeightQuery::build(
-            DaCompressedBlockWithBlockIdByHeightArgs {
-                height: height.into(),
-            },
+            DaCompressedBlockWithBlockIdByHeightArgs::new(height),
         );
         let da_compressed_block = self.query(query).await?;
 

--- a/packages/fuel/src/lib.rs
+++ b/packages/fuel/src/lib.rs
@@ -27,7 +27,7 @@ impl ports::fuel::Api for client::HttpClient {
     fn full_blocks_in_height_range(
         &self,
         range: RangeInclusive<u32>,
-    ) -> BoxStream<'_, Result<Vec<ports::fuel::FullFuelBlock>>> {
+    ) -> BoxStream<'_, Result<Vec<ports::fuel::MaybeCompressedFuelBlock>>> {
         self.block_in_height_range(range).boxed()
     }
 }
@@ -101,7 +101,7 @@ mod tests {
         // killing the node once the SDK supports it.
         let url = Url::parse("localhost:12344").unwrap();
 
-        let fuel_adapter = HttpClient::new(&url, 1, 1.try_into().unwrap());
+        let fuel_adapter = HttpClient::new(&url, 1);
 
         let registry = Registry::default();
         fuel_adapter.register_metrics(&registry);
@@ -128,7 +128,7 @@ mod tests {
         // killing the node once the SDK supports it.
         let url = Url::parse("http://localhost:12344").unwrap();
 
-        let fuel_adapter = client::HttpClient::new(&url, 3, 1.try_into().unwrap());
+        let fuel_adapter = client::HttpClient::new(&url, 3);
         let health_check = fuel_adapter.connection_health_checker();
 
         assert!(health_check.healthy());

--- a/packages/ports/Cargo.toml
+++ b/packages/ports/Cargo.toml
@@ -14,6 +14,7 @@ alloy = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 delegate = { workspace = true, optional = true }
 fuel-core-client = { workspace = true, optional = true }
+fuel-core-types = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 itertools = { workspace = true, features = ["use_std"], optional = true }
 mockall = { workspace = true, optional = true }

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -38,30 +38,6 @@ pub enum MaybeCompressedFuelBlock {
     Uncompressed(FullFuelBlock),
 }
 
-impl MaybeCompressedFuelBlock {
-    pub fn as_full_block(&self) -> Option<&FullFuelBlock> {
-        match self {
-            MaybeCompressedFuelBlock::Uncompressed(block) => Some(block),
-            _ => None,
-        }
-    }
-
-    pub fn as_compressed_block(&self) -> Option<&CompressedBlock> {
-        match self {
-            MaybeCompressedFuelBlock::Compressed(block) => Some(block),
-            _ => None,
-        }
-    }
-
-    pub fn is_compressed(&self) -> bool {
-        matches!(self, MaybeCompressedFuelBlock::Compressed(_))
-    }
-
-    pub fn is_uncompressed(&self) -> bool {
-        matches!(self, MaybeCompressedFuelBlock::Uncompressed(_))
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -51,7 +51,7 @@ impl MaybeCompressedFuelBlock {
             Self::Compressed(_) => Err(Error::Other(
                 "Cannot convert compressed block to uncompressed".to_string(),
             )),
-            Self::Uncompressed(block) => Ok(block.clone()),
+            Self::Uncompressed(block) => Ok(block),
         }
     }
 }

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -38,6 +38,12 @@ pub enum MaybeCompressedFuelBlock {
     Uncompressed(FullFuelBlock),
 }
 
+impl From<FullFuelBlock> for MaybeCompressedFuelBlock {
+    fn from(block: FullFuelBlock) -> Self {
+        Self::Uncompressed(block)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -45,15 +45,6 @@ impl MaybeCompressedFuelBlock {
             Self::Uncompressed(block) => block.header.height,
         }
     }
-
-    pub fn into_uncompressed(self) -> Result<FullFuelBlock> {
-        match self {
-            Self::Compressed(_) => Err(Error::Other(
-                "Cannot convert compressed block to uncompressed".to_string(),
-            )),
-            Self::Uncompressed(block) => Ok(block),
-        }
-    }
 }
 
 impl From<FullFuelBlock> for MaybeCompressedFuelBlock {

--- a/packages/ports/src/ports/fuel.rs
+++ b/packages/ports/src/ports/fuel.rs
@@ -38,6 +38,24 @@ pub enum MaybeCompressedFuelBlock {
     Uncompressed(FullFuelBlock),
 }
 
+impl MaybeCompressedFuelBlock {
+    pub fn height(&self) -> u32 {
+        match self {
+            Self::Compressed(block) => block.height,
+            Self::Uncompressed(block) => block.header.height,
+        }
+    }
+
+    pub fn into_uncompressed(self) -> Result<FullFuelBlock> {
+        match self {
+            Self::Compressed(_) => Err(Error::Other(
+                "Cannot convert compressed block to uncompressed".to_string(),
+            )),
+            Self::Uncompressed(block) => Ok(block.clone()),
+        }
+    }
+}
+
 impl From<FullFuelBlock> for MaybeCompressedFuelBlock {
     fn from(block: FullFuelBlock) -> Self {
         Self::Uncompressed(block)

--- a/packages/ports/src/ports/storage.rs
+++ b/packages/ports/src/ports/storage.rs
@@ -146,6 +146,12 @@ impl TryFrom<NonEmpty<FuelBlock>> for SequentialFuelBlocks {
     }
 }
 
+impl From<SequentialFuelBlocks> for NonEmpty<FuelBlock> {
+    fn from(blocks: SequentialFuelBlocks) -> Self {
+        blocks.blocks
+    }
+}
+
 impl TryFrom<NonEmpty<SerializedFuelBlock>> for SequentialFuelBlocks {
     type Error = InvalidSequence;
 

--- a/packages/ports/src/ports/storage.rs
+++ b/packages/ports/src/ports/storage.rs
@@ -190,7 +190,9 @@ impl TryFrom<SerializedFuelBlock> for ports::storage::FuelBlock {
             SerializedFuelBlock::Compressed(block) => Ok(ports::storage::FuelBlock {
                 hash: block.hash.into(),
                 height: block.height,
-                data: NonEmpty::collect(block.data).expect("at least one byte"),
+                data: NonEmpty::collect(block.data).ok_or(Error::Conversion(
+                    "failed to convert compressed block data".to_string(),
+                ))?,
             }),
             SerializedFuelBlock::Uncompressed(block) => Ok(block),
         }

--- a/packages/ports/src/ports/storage.rs
+++ b/packages/ports/src/ports/storage.rs
@@ -146,12 +146,6 @@ impl TryFrom<NonEmpty<FuelBlock>> for SequentialFuelBlocks {
     }
 }
 
-impl From<SequentialFuelBlocks> for NonEmpty<FuelBlock> {
-    fn from(blocks: SequentialFuelBlocks) -> Self {
-        blocks.blocks
-    }
-}
-
 impl TryFrom<NonEmpty<SerializedFuelBlock>> for SequentialFuelBlocks {
     type Error = InvalidSequence;
 

--- a/packages/services/src/block_bundler.rs
+++ b/packages/services/src/block_bundler.rs
@@ -423,7 +423,7 @@ mod tests {
 
         let clock = TestClock::default();
 
-        let latest_height = blocks.last().header.height;
+        let latest_height = blocks.last().height();
         let mock_fuel_api = test_utils::mocks::fuel::latest_height_is(latest_height);
 
         let mut block_bundler = BlockBundler::new(
@@ -458,7 +458,7 @@ mod tests {
 
         assert!(setup
             .db()
-            .lowest_sequence_of_unbundled_blocks(blocks.last().header.height, 1)
+            .lowest_sequence_of_unbundled_blocks(blocks.last().height(), 1)
             .await?
             .is_none());
 
@@ -482,7 +482,7 @@ mod tests {
             .await;
 
         let mut block_bundler = BlockBundler::new(
-            mocks::fuel::latest_height_is(fuel_blocks.last().header.height),
+            mocks::fuel::latest_height_is(fuel_blocks.last().height()),
             setup.db(),
             clock.clone(),
             default_bundler_factory(),
@@ -778,7 +778,7 @@ mod tests {
 
         let blocks_to_bundle: Vec<_> = blocks
             .iter()
-            .filter(|block| block.header.height >= starting_height)
+            .filter(|block| block.height() >= starting_height)
             .cloned()
             .collect();
 
@@ -788,7 +788,8 @@ mod tests {
             "Expected only one block to be within the lookback window"
         );
         assert_eq!(
-            blocks_to_bundle[0].header.height, 3,
+            blocks_to_bundle[0].height(),
+            3,
             "Expected block at height 3 to be within the lookback window"
         );
 
@@ -866,7 +867,7 @@ mod tests {
             })
             .await;
 
-        let latest_height = blocks.last().header.height;
+        let latest_height = blocks.last().height();
         let mock_fuel_api = test_utils::mocks::fuel::latest_height_is(latest_height);
 
         let registry = metrics::prometheus::Registry::new();
@@ -903,10 +904,7 @@ mod tests {
             .get_gauge()
             .get_value() as i64;
 
-        assert_eq!(
-            last_bundled_block_height,
-            blocks.last().header.height as i64
-        );
+        assert_eq!(last_bundled_block_height, blocks.last().height() as i64);
 
         // Check that the blocks_per_bundle metric has recorded the correct number of blocks
         let blocks_per_bundle_metric = gathered_metrics

--- a/packages/services/src/block_bundler/bundler.rs
+++ b/packages/services/src/block_bundler/bundler.rs
@@ -597,11 +597,13 @@ mod tests {
         let blocks = nonempty![
             generate_storage_block(0, &secret_key, 0, 100),
             generate_storage_block(1, &secret_key, 1, enough_bytes_to_almost_fill_a_blob())
-        ];
+        ]
+        .try_into()
+        .unwrap();
 
         let mut bundler = Bundler::new(
             Eip4844BlobEncoder,
-            blocks.clone().try_into().unwrap(),
+            blocks,
             Compressor::no_compression(),
             NonZeroUsize::new(1).unwrap(), // Default step size
         );

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -232,7 +232,7 @@ mod tests {
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use storage::{DbWithProcess, PostgresProcess};
 
-    use crate::{test_utils::mocks::l1::FullL1Mock, BlockValidator};
+    use crate::BlockValidator;
 
     use super::*;
 

--- a/packages/services/src/block_committer.rs
+++ b/packages/services/src/block_committer.rs
@@ -1,9 +1,5 @@
 use std::num::NonZeroU32;
 
-use metrics::{
-    prometheus::{core::Collector, IntGauge, Opts},
-    RegistersMetrics,
-};
 use ports::{
     fuel::FuelBlock,
     storage::Storage,

--- a/packages/services/src/block_importer.rs
+++ b/packages/services/src/block_importer.rs
@@ -479,7 +479,7 @@ mod tests {
                         .map(|height| {
                             test_utils::mocks::fuel::generate_block(height, &secret_key, 1, 100)
                         })
-                        .map(MaybeCompressedFuelBlock::Uncompressed)
+                        .map(MaybeCompressedFuelBlock::from)
                         .collect();
 
                     futures::stream::once(async { Ok(blocks) }).boxed()

--- a/packages/services/src/lib.rs
+++ b/packages/services/src/lib.rs
@@ -640,7 +640,7 @@ pub(crate) mod test_utils {
                                 size_per_tx,
                             )
                         })
-                        .map(MaybeCompressedFuelBlock::Uncompressed)
+                        .map(MaybeCompressedFuelBlock::from)
                         .collect_nonempty()
                         .unwrap();
 

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -70,7 +70,10 @@ impl Storage for Postgres {
             .map_err(Into::into)
     }
 
-    async fn insert_blocks(&self, blocks: NonEmpty<ports::storage::FuelBlock>) -> Result<()> {
+    async fn insert_blocks(
+        &self,
+        blocks: NonEmpty<ports::storage::SerializedFuelBlock>,
+    ) -> Result<()> {
         Ok(self._insert_blocks(blocks).await?)
     }
 

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -136,14 +136,14 @@ impl Storage for Postgres {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use itertools::Itertools;
+    use ports::storage::SerializedFuelBlock;
     use ports::{
         storage::{Error, Storage},
         types::{nonempty, CollectNonEmpty},
     };
     use rand::{thread_rng, Rng, SeedableRng};
-
-    use super::*;
 
     // Helper function to create a storage instance for testing
     async fn start_db() -> DbWithProcess {
@@ -423,6 +423,7 @@ mod tests {
                     data: block_data,
                 }
             })
+            .map(SerializedFuelBlock::Uncompressed)
             .collect_nonempty()
             .expect("shouldn't be empty");
 

--- a/packages/storage/src/mappings/tables.rs
+++ b/packages/storage/src/mappings/tables.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use num_bigint::BigInt;
+use ports::storage::SerializedFuelBlock;
 use ports::types::{BlockSubmissionTx, DateTime, NonEmpty, NonNegative, TransactionState, Utc};
 use sqlx::types::BigDecimal;
 
@@ -282,6 +283,16 @@ impl From<ports::storage::FuelBlock> for FuelBlock {
             hash: value.hash.to_vec(),
             height: value.height.into(),
             data: value.data.into(),
+        }
+    }
+}
+
+impl From<ports::storage::SerializedFuelBlock> for FuelBlock {
+    fn from(value: SerializedFuelBlock) -> Self {
+        Self {
+            hash: value.hash(),
+            height: value.height().into(),
+            data: value.data(),
         }
     }
 }

--- a/packages/storage/src/postgres.rs
+++ b/packages/storage/src/postgres.rs
@@ -351,7 +351,7 @@ impl Postgres {
 
     pub(crate) async fn _insert_blocks(
         &self,
-        blocks: NonEmpty<ports::storage::FuelBlock>,
+        blocks: NonEmpty<ports::storage::SerializedFuelBlock>,
     ) -> Result<()> {
         // Currently: hash, height and data
         const FIELDS_PER_BLOCK: u16 = 3;

--- a/packages/storage/src/test_instance.rs
+++ b/packages/storage/src/test_instance.rs
@@ -4,9 +4,11 @@ use std::{
     sync::{Arc, Weak},
 };
 
+use super::postgres::{DbConfig, Postgres};
 use delegate::delegate;
+use ports::storage::SerializedFuelBlock;
 use ports::{
-    storage::{BundleFragment, FuelBlock, SequentialFuelBlocks, Storage},
+    storage::{BundleFragment, SequentialFuelBlocks, Storage},
     types::{
         BlockSubmission, BlockSubmissionTx, DateTime, Fragment, L1Tx, NonEmpty, NonNegative,
         TransactionState, Utc,
@@ -18,8 +20,6 @@ use testcontainers::{
     runners::AsyncRunner,
     Image,
 };
-
-use super::postgres::{DbConfig, Postgres};
 
 struct PostgresImage {
     username: String,
@@ -175,7 +175,7 @@ impl Storage for DbWithProcess {
             async fn get_pending_block_submission_txs(&self, submission_id: NonNegative<i32>) -> ports::storage::Result<Vec<BlockSubmissionTx>>;
             async fn update_block_submission_tx(&self, hash: [u8; 32], state: TransactionState) -> ports::storage::Result<BlockSubmission>;
             async fn submission_w_latest_block(&self) -> ports::storage::Result<Option<BlockSubmission>>;
-            async fn insert_blocks(&self, blocks: NonEmpty<FuelBlock>) -> ports::storage::Result<()>;
+            async fn insert_blocks(&self, blocks: NonEmpty<SerializedFuelBlock>) -> ports::storage::Result<()>;
             async fn missing_blocks(&self, starting_height: u32, current_height: u32) -> ports::storage::Result<Vec<RangeInclusive<u32>>>;
             async fn lowest_sequence_of_unbundled_blocks(
                 &self,


### PR DESCRIPTION
- **chore(fuel-core): bump to v0.38**
- **feat(compression): include da compressed blocks into the block importer**

Incrementally fetches blocks instead of fetching by range, if a da compressed block exists, it inserts that into storage, if not, it fetches the full block and inserts that into storage.
