### PR TITLE
chore: add cargo hack to CI for feature combinations check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,24 @@ jobs:
       - name: Unit/integration tests
         run:  cargo test --workspace --exclude e2e
 
+  additional-check-for-published-crates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Run cargo hack to check for invalid feature flag combinations
+        uses: taiki-e/install-action@cargo-hack
+        working-directory: packages/encoding
+        run: cargo hack --feature-powerset --no-dev-deps check
+
   e2e-release-build:
     runs-on: ubuntu-latest
     steps:
@@ -315,6 +333,7 @@ jobs:
   publish:
     needs:
       - cargo-verifications
+      - additional-check-for-published-crates
       - publish-crates-check
     # Only do this job if publishing a release
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,10 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - name: Run cargo hack to check for invalid feature flag combinations
+      - name: Setup cargo hack
         uses: taiki-e/install-action@cargo-hack
+
+      - name: Run cargo hack to check for invalid feature flag combinations
         working-directory: packages/encoding
         run: cargo hack --feature-powerset --no-dev-deps check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clock"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clock",
  "ports",
@@ -2466,7 +2466,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "eth"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2809,7 +2809,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuel"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "delegate",
  "fuel-core-client",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-committer"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-committer-encoding"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3821,23 +3821,23 @@ checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
 
 [[package]]
 name = "impl-tools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82c305b1081f1a99fda262883c788e50ab57d36c00830bdd7e0a82894ad965c"
+checksum = "8a84bc8d2baf8da56e93b4247067d918e1a44829bbbe3e4b875aaf8d7d3c7bc9"
 dependencies = [
  "autocfg",
  "impl-tools-lib",
- "proc-macro-error",
+ "proc-macro-error2",
  "syn 2.0.79",
 ]
 
 [[package]]
 name = "impl-tools-lib"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d3946d886eaab0702fa0c6585adcced581513223fa9df7ccfabbd9fa331a88"
+checksum = "a795a1e201125947a063b967c79de6ae152143ab522f481d4f493c44835ba37a"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4116,7 +4116,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "metrics"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "prometheus",
 ]
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "ports"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -4701,29 +4701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -5634,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "services"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bytesize",
  "clock",
@@ -6031,7 +6008,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "delegate",
  "hex",

--- a/packages/encoding/Cargo.toml
+++ b/packages/encoding/Cargo.toml
@@ -13,13 +13,13 @@ publish = true
 # alloy only really needed when generating proofs, and since the core doesn't
 # need to do that we've gated it behing the `kzg` feature flag.
 alloy = { workspace = true, features = ["consensus", "eips"], optional = true }
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ["default"] }
 bitvec = { workspace = true, features = ["default"] }
 c-kzg = { workspace = true }
 flate2 = { workspace = true, features = ["default"] }
 hex = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
-postcard = { workspace = true, features = ["alloc"] }
+postcard = { workspace = true, features = ["use-std"] }
 serde = { workspace = true }
 static_assertions = { workspace = true }
 


### PR DESCRIPTION
We now check the crates we publish in isolation from the workspace and with all possible feature flag combinations.