### PR TITLE
bug: add description for package

### DIFF
--- a/packages/encoding/Cargo.toml
+++ b/packages/encoding/Cargo.toml
@@ -7,6 +7,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
+description = "Used to encode/decode bundles created by the fuel block committer."
 publish = true
 
 [dependencies]


### PR DESCRIPTION
Even the dry running of a release doesn't catch the issue that crates.io will reject the package if it doesn't have the description set.