### PR TITLE
feat!: get latest costs from api

### DIFF
--- a/.sqlx/query-39d3fae6fdd67a2324fae4d5e828f69f2298cd5b0f7eb1609ed189269c6f677c.json
+++ b/.sqlx/query-39d3fae6fdd67a2324fae4d5e828f69f2298cd5b0f7eb1609ed189269c6f677c.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                bc.bundle_id,\n                bc.cost,\n                bc.size,\n                bc.da_block_height,\n                bc.is_finalized,\n                b.start_height,\n                b.end_height\n            FROM\n                bundle_cost bc\n                JOIN bundles b ON bc.bundle_id = b.id\n            WHERE\n                bc.is_finalized = TRUE\n            ORDER BY\n                b.start_height DESC\n            LIMIT $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bundle_id",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "cost",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 2,
+        "name": "size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "da_block_height",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_finalized",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "start_height",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "end_height",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "39d3fae6fdd67a2324fae4d5e828f69f2298cd5b0f7eb1609ed189269c6f677c"
+}

--- a/committer/src/api.rs
+++ b/committer/src/api.rs
@@ -90,7 +90,7 @@ async fn metrics(registry: web::Data<Arc<Registry>>) -> impl Responder {
     std::result::Result::<_, InternalError<_>>::Ok(text)
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
 enum HeightVariant {
     Latest,

--- a/committer/src/api.rs
+++ b/committer/src/api.rs
@@ -91,8 +91,16 @@ async fn metrics(registry: web::Data<Arc<Registry>>) -> impl Responder {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum HeightVariant {
+    Latest,
+    Specific,
+}
+
+#[derive(Deserialize)]
 struct CostQueryParams {
-    from_height: u32,
+    variant: HeightVariant,
+    value: Option<u32>,
     limit: Option<usize>,
 }
 
@@ -103,8 +111,18 @@ async fn costs(
 ) -> impl Responder {
     let limit = query.limit.unwrap_or(100);
 
-    match data.get_costs(query.from_height, limit).await {
-        Ok(bundle_costs) => HttpResponse::Ok().json(bundle_costs),
+    let response = match query.variant {
+        HeightVariant::Latest => data.get_latest_costs(limit).await,
+        HeightVariant::Specific => match query.value {
+            Some(height) => data.get_costs(height, limit).await,
+            None => Err(services::Error::Other(
+                "height value is required".to_string(),
+            )),
+        },
+    };
+
+    match response {
+        Ok(costs) => HttpResponse::Ok().json(costs),
         Err(services::Error::Other(e)) => {
             HttpResponse::from_error(InternalError::new(e, StatusCode::BAD_REQUEST))
         }

--- a/e2e/src/committer.rs
+++ b/e2e/src/committer.rs
@@ -295,7 +295,7 @@ impl CommitterProcess {
         limit: usize,
     ) -> anyhow::Result<Vec<BundleCost>> {
         let response = reqwest::get(format!(
-            "http://localhost:{}/v1/costs?from_height={}&limit={}",
+            "http://localhost:{}/v1/costs?variant=specific&value={}&limit={}",
             self.port, from_height, limit
         ))
         .await?

--- a/packages/adapters/storage/src/postgres.rs
+++ b/packages/adapters/storage/src/postgres.rs
@@ -861,6 +861,36 @@ impl Postgres {
         .collect::<Result<Vec<_>>>()
     }
 
+    pub(crate) async fn _get_latest_costs(&self, limit: usize) -> Result<Vec<BundleCost>> {
+        sqlx::query_as!(
+            tables::BundleCost,
+            r#"
+            SELECT
+                bc.bundle_id,
+                bc.cost,
+                bc.size,
+                bc.da_block_height,
+                bc.is_finalized,
+                b.start_height,
+                b.end_height
+            FROM
+                bundle_cost bc
+                JOIN bundles b ON bc.bundle_id = b.id
+            WHERE
+                bc.is_finalized = TRUE
+            ORDER BY
+                b.start_height DESC
+            LIMIT $1
+            "#,
+            limit as i64
+        )
+        .fetch_all(&self.connection_pool)
+        .await?
+        .into_iter()
+        .map(BundleCost::try_from)
+        .collect::<Result<Vec<_>>>()
+    }
+
     pub(crate) async fn _next_bundle_id(&self) -> Result<NonNegative<i32>> {
         let next_id = sqlx::query!("SELECT nextval(pg_get_serial_sequence('bundles', 'id'))")
             .fetch_one(&self.connection_pool)

--- a/packages/adapters/storage/src/test_instance.rs
+++ b/packages/adapters/storage/src/test_instance.rs
@@ -1,9 +1,3 @@
-use std::{
-    borrow::Cow,
-    ops::RangeInclusive,
-    sync::{Arc, Weak},
-};
-
 use delegate::delegate;
 use services::{
     block_bundler, block_committer, block_importer,
@@ -14,6 +8,11 @@ use services::{
     },
 };
 use sqlx::Executor;
+use std::{
+    borrow::Cow,
+    ops::RangeInclusive,
+    sync::{Arc, Weak},
+};
 use testcontainers::{
     core::{ContainerPort, WaitFor},
     runners::AsyncRunner,
@@ -350,5 +349,9 @@ impl services::cost_reporter::port::Storage for DbWithProcess {
             ._get_finalized_costs(from_block_height, limit)
             .await
             .map_err(Into::into)
+    }
+
+    async fn get_latest_costs(&self, limit: usize) -> services::Result<Vec<BundleCost>> {
+        self.db._get_latest_costs(limit).await.map_err(Into::into)
     }
 }

--- a/packages/services/src/cost_reporter.rs
+++ b/packages/services/src/cost_reporter.rs
@@ -36,6 +36,17 @@ pub mod service {
                 .get_finalized_costs(from_block_height, limit)
                 .await
         }
+
+        pub async fn get_latest_costs(&self, limit: usize) -> Result<Vec<BundleCost>> {
+            if limit > self.request_limit {
+                return Err(Error::Other(format!(
+                    "requested: {} items, but limit is: {}",
+                    limit, self.request_limit
+                )));
+            }
+
+            self.storage.get_latest_costs(limit).await
+        }
     }
 }
 
@@ -50,5 +61,7 @@ pub mod port {
             from_block_height: u32,
             limit: usize,
         ) -> Result<Vec<BundleCost>>;
+
+        async fn get_latest_costs(&self, limit: usize) -> Result<Vec<BundleCost>>;
     }
 }


### PR DESCRIPTION
Extends the costs api to support fetching the latest cost entries

BREAKING CHANGE: new query parameter needs to be specified `variant = specific | latest `
