### PR TITLE
fix(fuel-block-committer-encoding): make c-kzg dependency optional

### DIFF
--- a/packages/encoding/Cargo.toml
+++ b/packages/encoding/Cargo.toml
@@ -16,7 +16,7 @@ publish = true
 alloy = { workspace = true, features = ["consensus", "eips"], optional = true }
 anyhow = { workspace = true, features = ["default"] }
 bitvec = { workspace = true, features = ["default"] }
-c-kzg = { workspace = true }
+c-kzg = { workspace = true, optional = true }
 flate2 = { workspace = true, features = ["default"] }
 hex = { workspace = true }
 itertools = { workspace = true, features = ["use_std"] }
@@ -37,4 +37,4 @@ test-case = { workspace = true }
 
 [features]
 default = []
-kzg = ["alloy/kzg"]
+kzg = ["alloy/kzg", "dep:c-kzg"]

--- a/packages/encoding/Cargo.toml
+++ b/packages/encoding/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { workspace = true, features = ["default"] }
 bitvec = { workspace = true, features = ["default"] }
 c-kzg = { workspace = true, optional = true }
 flate2 = { workspace = true, features = ["default"] }
-hex = { workspace = true }
+hex = { workspace = true, features = ["alloc"] }
 itertools = { workspace = true, features = ["use_std"] }
 postcard = { workspace = true, features = ["use-std"] }
 serde = { workspace = true }


### PR DESCRIPTION
this was preventing the crate from compiling in risc0/sp1
