### PR TITLE
chore(encoding): use sp1s kzg-rs to verify c-kzg generated proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,7 +995,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1004,7 +1015,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -1037,7 +1048,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1049,7 +1060,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1074,7 +1085,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -1702,7 +1713,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -1712,6 +1723,15 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -2994,8 +3014,25 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "byteorder",
+ "ff_derive",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3153,10 +3190,12 @@ dependencies = [
  "fuel-block-committer-encoding",
  "hex",
  "itertools 0.13.0",
+ "kzg-rs",
  "postcard",
  "proptest",
  "rand",
  "serde",
+ "sha2",
  "static_assertions",
  "test-case",
 ]
@@ -4376,6 +4415,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kzg-rs"
+version = "0.2.3"
+source = "git+https://github.com/rymnc/kzg-rs?rev=a3af3fd#a3af3fdd07dffccc6adb8044dc478b5ed061353a"
+dependencies = [
+ "ff",
+ "hex",
+ "sha2",
+ "sp1_bls12_381",
+ "spin",
+]
+
+[[package]]
 name = "lalrpop-util"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4696,6 +4747,17 @@ checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
 
 [[package]]
 name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
@@ -4893,6 +4955,15 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
 ]
 
 [[package]]
@@ -5647,7 +5718,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "bytes",
  "fastrlp",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -5881,6 +5952,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6269,6 +6364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "snowbridge-amcl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460a9ed63cdf03c1b9847e8a12a5f5ba19c4efd5869e4a737e05be25d7c427e5"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6276,6 +6381,35 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "sp1-lib"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea7811abd2d3a991007fcb284f41152840b8388c171288d0c52c6793956609c"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "hex",
+ "serde",
+ "snowbridge-amcl",
+]
+
+[[package]]
+name = "sp1_bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27c4b8901334dc09099dd82f80a72ddfc76b0046f4b342584c808f1931bed5a"
+dependencies = [
+ "cfg-if",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "sp1-lib",
+ "subtle",
 ]
 
 [[package]]
@@ -6476,7 +6610,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "num-bigint",
+ "num-bigint 0.4.6",
  "once_cell",
  "rand",
  "serde",
@@ -6544,7 +6678,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "metrics",
- "num-bigint",
+ "num-bigint 0.4.6",
  "rand",
  "serde",
  "services",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,5 @@ walkdir = { version = "2.5", default-features = false }
 zip = { version = "2.1", default-features = false }
 cynic = { version = "3.1", default-features = false }
 cynic-codegen = { version = "3.10", default-features = false }
+kzg-rs = { git = "https://github.com/rymnc/kzg-rs", rev = "a3af3fd", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }

--- a/packages/encoding/Cargo.toml
+++ b/packages/encoding/Cargo.toml
@@ -23,6 +23,8 @@ itertools = { workspace = true, features = ["use_std"] }
 postcard = { workspace = true, features = ["use-std"] }
 serde = { workspace = true }
 static_assertions = { workspace = true }
+kzg-rs = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy = { workspace = true, features = ["consensus", "eips", "kzg"] }
@@ -36,5 +38,6 @@ rand = { workspace = true, features = ["std", "std_rng", "small_rng"] }
 test-case = { workspace = true }
 
 [features]
-default = []
+default = ["native-kzg-verify"]
 kzg = ["alloy/kzg", "dep:c-kzg"]
+native-kzg-verify = ["dep:kzg-rs", "dep:sha2"]

--- a/packages/encoding/src/blob.rs
+++ b/packages/encoding/src/blob.rs
@@ -49,3 +49,232 @@ pub fn generate_sidecar(
         proofs,
     ))
 }
+
+#[cfg(feature = "native-kzg-verify")]
+pub mod native_kzg_verify {
+    use kzg_rs::{
+        kzg_proof::{
+            safe_g1_affine_from_bytes,
+            G1Projective, G2Projective, Scalar,
+        },
+        pairings_verify, KzgSettings,
+    };
+
+    #[cfg(feature = "kzg")]
+    use kzg_rs::kzg_proof::{compute_challenge, evaluate_polynomial_in_evaluation_form};
+    #[cfg(feature = "kzg")]
+    use sha2::Digest;
+
+
+    #[cfg(feature = "kzg")]
+    pub fn verify_kzg_sidecar(
+        kzg_settings: &KzgSettings,
+        sidecar: alloy::consensus::BlobTransactionSidecar,
+    ) -> anyhow::Result<bool> {
+        use kzg_rs::KzgProof;
+
+        let VerifierSidecar {
+            blobs,
+            proofs,
+            commitments,
+        } = transmute_sidecar(sidecar);
+
+        let is_verified =
+            KzgProof::verify_blob_kzg_proof_batch(blobs, commitments, proofs, &kzg_settings)
+                .map_err(|e| anyhow::anyhow!("couldn't verify proof: {e:?}"))?;
+
+        Ok(is_verified)
+    }
+
+    #[cfg(feature = "kzg")]
+    pub struct VerifierSidecar {
+        blobs: Vec<kzg_rs::Blob>,
+        proofs: Vec<kzg_rs::Bytes48>,
+        commitments: Vec<kzg_rs::Bytes48>,
+    }
+
+    #[cfg(feature = "kzg")]
+    pub fn transmute_sidecar(sidecar: alloy::consensus::BlobTransactionSidecar) -> VerifierSidecar {
+        let mut blobs = Vec::with_capacity(sidecar.blobs.len());
+        let mut commitments = Vec::with_capacity(sidecar.commitments.len());
+        let mut proofs = Vec::with_capacity(sidecar.proofs.len());
+
+        for blob in sidecar.blobs {
+            // SAFETY: same size, 131072 bytes
+            unsafe {
+                blobs.push(core::mem::transmute::<
+                    alloy::eips::eip4844::Blob,
+                    kzg_rs::Blob,
+                >(blob));
+            }
+        }
+
+        for commitment in sidecar.commitments {
+            // SAFETY: same size, 48 bytes
+            unsafe {
+                commitments.push(core::mem::transmute::<
+                    alloy::eips::eip4844::Bytes48,
+                    kzg_rs::Bytes48,
+                >(commitment));
+            }
+        }
+
+        for proof in sidecar.proofs {
+            // SAFETY: same size, 48 bytes
+            unsafe {
+                proofs.push(core::mem::transmute::<
+                    alloy::eips::eip4844::Bytes48,
+                    kzg_rs::Bytes48,
+                >(proof));
+            }
+        }
+
+        VerifierSidecar {
+            blobs,
+            commitments,
+            proofs,
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct PrecompileInput {
+        pub commitment: kzg_rs::Bytes48,
+        pub proof: kzg_rs::Bytes48,
+        pub z: Scalar,
+        pub y: Scalar,
+        pub versioned_hash: [u8; 32],
+    }
+
+    #[cfg(feature = "kzg")]
+    pub fn commitment_to_versioned_hash(commitment: &kzg_rs::Bytes48) -> [u8; 32] {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(commitment.as_slice());
+        let hashed_commitment = hasher.finalize();
+
+        static KZG_VERSIONED_HASH: u8 = 0x01;
+
+        let mut result = [0u8; 32];
+        result.copy_from_slice(hashed_commitment.as_slice());
+        result[0] = KZG_VERSIONED_HASH;
+        result
+    }
+
+    #[cfg(feature = "kzg")]
+    pub fn generate_precompile_inputs(
+        kzg_settings: &KzgSettings,
+        sidecar: alloy::eips::eip4844::BlobTransactionSidecar,
+    ) -> anyhow::Result<Vec<PrecompileInput>> {
+        let mut precompile_inputs = Vec::with_capacity(sidecar.blobs.len());
+
+        let sidecar = transmute_sidecar(sidecar);
+
+        for i in 0..sidecar.blobs.len() {
+            let commitment = sidecar.commitments[i].clone();
+            let commitment_on_curve = safe_g1_affine_from_bytes(&commitment)
+                .map_err(|e| anyhow::anyhow!("cant cast to g1 affine: {e:?}"))?;
+            let proof = sidecar.proofs[i].clone();
+            let versioned_hash = commitment_to_versioned_hash(&commitment);
+
+            let polynomial = sidecar.blobs[i]
+                .as_polynomial()
+                .map_err(|e| anyhow::anyhow!("cant convert blob to polynomial: {e:?}"))?;
+            let z = compute_challenge(&sidecar.blobs[i], &commitment_on_curve)
+                .map_err(|e| anyhow::anyhow!("cant compute challenge: {e:?}"))?;
+            let y = evaluate_polynomial_in_evaluation_form(polynomial, z, &kzg_settings)
+                .map_err(|e| anyhow::anyhow!("cant evaluate polynomial: {e:?}"))?;
+
+            precompile_inputs.push(PrecompileInput {
+                commitment,
+                proof,
+                versioned_hash,
+                z,
+                y,
+            });
+        }
+
+        Ok(precompile_inputs)
+    }
+
+    pub fn verify_precompile_inputs(
+        kzg_settings: &KzgSettings,
+        precompile_inputs: Vec<PrecompileInput>,
+    ) -> anyhow::Result<bool> {
+        for precompile_input in precompile_inputs {
+            let commitment_on_curve = safe_g1_affine_from_bytes(&precompile_input.commitment)
+                .map_err(|e| anyhow::anyhow!("cant cast to g1 affine: {e:?}"))?;
+
+            // investigate if we need to do the subtractio
+            // no idea if precompile uses multi-miller loop pairing or not
+            let x = G2Projective::generator() * precompile_input.z;
+            let x_minus_z = kzg_settings.g2_points[1] - x;
+
+            let y = G1Projective::generator() * precompile_input.y;
+            let p_minus_y = commitment_on_curve - y;
+
+            let res = pairings_verify(
+                p_minus_y.into(),
+                G2Projective::generator().into(),
+                safe_g1_affine_from_bytes(&precompile_input.proof)
+                    .map_err(|e| anyhow::anyhow!(e))?,
+                x_minus_z.into(),
+            );
+
+            match res {
+                true => continue,
+                false => return Ok(false),
+            }
+        }
+
+        Ok(true)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::blob::{generate_sidecar, native_kzg_verify::PrecompileInput};
+
+        use super::{generate_precompile_inputs, verify_kzg_sidecar, verify_precompile_inputs};
+
+        #[test]
+        fn sidecar_generated_by_c_kzg_is_verified_by_kzg_rs() {
+            let kzg_settings = kzg_rs::KzgSettings::load_trusted_setup_file().unwrap();
+
+            let blob_count = 3;
+            let mut blobs = Vec::with_capacity(blob_count);
+
+            for _ in 0..blob_count {
+                blobs.push(Box::new([1u8; 131072]));
+            }
+
+            let sidecar = generate_sidecar(blobs).unwrap();
+
+            let sidecar_verified = verify_kzg_sidecar(&kzg_settings, sidecar).unwrap();
+
+            assert!(sidecar_verified);
+        }
+
+        #[test]
+        fn sidecar_generated_by_c_kzg_can_produce_verifiable_precompile_input() {
+            let kzg_settings = kzg_rs::KzgSettings::load_trusted_setup_file().unwrap();
+
+            let blob_count = 3;
+            let mut blobs = Vec::with_capacity(blob_count);
+
+            for _ in 0..blob_count {
+                blobs.push(Box::new([1u8; 131072]));
+            }
+
+            let sidecar = generate_sidecar(blobs).unwrap();
+
+            let precompile_inputs = generate_precompile_inputs(&kzg_settings, sidecar).unwrap();
+
+            let res = verify_precompile_inputs(&kzg_settings, precompile_inputs).unwrap();
+
+            assert!(res);
+        }
+
+        #[test]
+        fn size_of_precompile_input_matches_ethereum_precompile_input_size() {
+            assert_eq!(core::mem::size_of::<PrecompileInput>(), 192);
+        }
+    }
+}


### PR DESCRIPTION
required for fault proving. we cannot generate proofs within the zkvm context, so we will generate them in the host, and then pass the `PrecompileInput` in as private inputs to the zkvm. these can then be verified in the zkvm, and piped to the output for verification in the `0x0a` precompile on ethereum
