### PR TITLE
fix: uncontrolled block memory growth fuel-simulator

### DIFF
--- a/fuel_simulator/src/main.rs
+++ b/fuel_simulator/src/main.rs
@@ -10,6 +10,7 @@ struct Args {
     #[arg(long, default_value_t = 128)]
     block_size: usize,
 
+    /// port to run the server on.
     #[arg(long, default_value_t = 4000)]
     port: u16,
 }


### PR DESCRIPTION
Simple fix for the `fuel-simulator` for running integration tests. we ensure here that we don't have uncontrolled growth in memory. the blocks vec now holds a maximum of 10_000 blocks, so the max memory usage of this structure at peak is `(10_000 * (128 + 28 + 4)) = 1.6 mb`. (with the default block size set to 128 bytes)
