### PR TITLE
fix: eigen kms mod

### DIFF
--- a/packages/adapters/signers/src/eigen.rs
+++ b/packages/adapters/signers/src/eigen.rs
@@ -21,11 +21,10 @@ impl eigenda::Sign for Signer {
         match self {
             Signer::Private(signer) => {
                 // private_key.sign_digest cannot fail
-                let Ok(sig) = signer.sign_digest(message).await else {
-                    return Err(
-                        anyhow::anyhow!("Failed to sign digest with private key signer").into(),
-                    );
-                };
+                let sig = signer
+                    .sign_digest(message)
+                    .await
+                    .expect("Private key signing should never fail");
                 Ok(sig)
             }
             Signer::Kms(signer) => signer.sign_digest(message).await,

--- a/packages/adapters/signers/src/eth.rs
+++ b/packages/adapters/signers/src/eth.rs
@@ -8,12 +8,14 @@ use eth::Address;
 
 pub mod kms {
     pub use alloy::signers::aws::AwsSigner as Signer;
+    #[cfg(feature = "test-helpers")]
     use alloy::{
         consensus::SignableTransaction,
         network::TxSigner,
         primitives::{B256, ChainId},
         signers::Signature,
     };
+    #[cfg(feature = "test-helpers")]
     use eth::Address;
 
     #[cfg(feature = "test-helpers")]
@@ -24,6 +26,7 @@ pub mod kms {
         pub signer: Signer,
     }
 
+    #[cfg(feature = "test-helpers")]
     #[async_trait::async_trait]
     impl TxSigner<Signature> for TestEthKmsSigner {
         fn address(&self) -> Address {
@@ -38,6 +41,7 @@ pub mod kms {
         }
     }
 
+    #[cfg(feature = "test-helpers")]
     #[async_trait::async_trait]
     impl alloy::signers::Signer<Signature> for TestEthKmsSigner {
         async fn sign_hash(&self, hash: &B256) -> alloy::signers::Result<Signature> {

--- a/packages/adapters/signers/src/kms_utils.rs
+++ b/packages/adapters/signers/src/kms_utils.rs
@@ -1,4 +1,4 @@
-use aws_config::{Region, SdkConfig, default_provider::credentials::DefaultCredentialsChain};
+use aws_config::{SdkConfig, default_provider::credentials::DefaultCredentialsChain};
 use aws_sdk_kms::config::BehaviorVersion;
 
 pub async fn load_config_from_env() -> SdkConfig {
@@ -24,7 +24,7 @@ pub async fn config_for_testing(url: String) -> SdkConfig {
             "Static Credentials",
         ))
         .endpoint_url(url)
-        .region(Region::new("us-east-1")) // placeholder region for test
+        .region(aws_config::Region::new("us-east-1")) // placeholder region for test
         .load()
         .await
 }


### PR DESCRIPTION
fixes the unnecessary casts and cleans up the module. it also has dedicated error handling now


ai generated desc:

Key changes include replacing `anyhow` errors with a custom `Error` type, improving KMS integration, and adding conditional compilation for test helpers.

### Error Handling Improvements:
* [`packages/adapters/signers/src/eigen/kms.rs`](diffhunk://#diff-6c5f639903971e7c817428d302e0ec1e3a2385a2dd4620364577d074f39c06aaL1-L216): Replaced `anyhow` errors with a custom `Error` enum to provide more granular and descriptive error handling for KMS operations. This includes errors for missing keys, invalid DER formats, and recovery ID issues.

### Code Refinements:
* [`packages/adapters/signers/src/eigen.rs`](diffhunk://#diff-bc982a95fa96b121cae105051a60f994a44a6cb7dd25d1e696d4b37876bba399L24-R27): Simplified error handling in `Signer::Private` by using `.expect()` for cases where signing with a private key cannot fail.
* [`packages/adapters/signers/src/kms_utils.rs`](diffhunk://#diff-5b896acfb448ebfbad8e29f94877a5952f579f6d57dd3bad119ee01131307363L27-R27): Updated region handling in `config_for_testing` to use `aws_config::Region` directly, improving consistency with the AWS SDK.

### Testability Enhancements:
* [`packages/adapters/signers/src/eth.rs`](diffhunk://#diff-baad7500a3aca46d150f50157e446d74043526803cb3b7c447142ade3db85897R11-R18): Added conditional compilation (`#[cfg(feature = "test-helpers")]`) for test-related helper methods and imports to isolate test-specific functionality. [[1]](diffhunk://#diff-baad7500a3aca46d150f50157e446d74043526803cb3b7c447142ade3db85897R11-R18) [[2]](diffhunk://#diff-baad7500a3aca46d150f50157e446d74043526803cb3b7c447142ade3db85897R29) [[3]](diffhunk://#diff-baad7500a3aca46d150f50157e446d74043526803cb3b7c447142ade3db85897R44)