### PR TITLE
fix: serde annotation

### DIFF
--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -93,7 +93,7 @@ pub struct Fuel {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type")]
 pub enum DALayer {
     #[serde(rename = "EigenDA")]
     EigenDA(EigenDaConfig),


### PR DESCRIPTION
serde annotation for `DaLayer` cfg. we will perhaps need this on `EigenDaConfig` later, but i don't see a use for it now
