### PR TITLE
fix(eigen_bundler): unused bytes and total bytes calculation

### DIFF
--- a/packages/services/src/block_bundler/eigen_bundler.rs
+++ b/packages/services/src/block_bundler/eigen_bundler.rs
@@ -591,10 +591,18 @@ mod tests {
 
         // Verify fragments structure
         assert!(!bundle_proposal.fragments.is_empty());
-        for fragment in bundle_proposal.fragments.iter() {
-            assert!(!fragment.data.is_empty());
-            assert_eq!(fragment.total_bytes, fragment_size);
-            assert_eq!(fragment.unused_bytes, 0);
+
+        let len = bundle_proposal.fragments.len();
+        for (i, fragment) in bundle_proposal.fragments.iter().enumerate() {
+            if i < len - 1 {
+                assert!(!fragment.data.is_empty());
+                assert_eq!(fragment.total_bytes, fragment_size);
+                assert_eq!(fragment.unused_bytes, 0);
+            } else {
+                // Different assertions for the last fragment
+                assert!(fragment.total_bytes <= fragment_size);
+                assert!(fragment.unused_bytes > 0);
+            }
         }
 
         // Verify fragment count calculation

--- a/packages/services/src/block_bundler/eigen_bundler.rs
+++ b/packages/services/src/block_bundler/eigen_bundler.rs
@@ -103,8 +103,8 @@ where
             .chunks(fragment_size.get() as usize)
             .map(|chunk| Fragment {
                 data: NonEmpty::from_vec(chunk.to_vec()).expect("chunk should not be empty"),
-                unused_bytes: 0,
-                total_bytes: fragment_size,
+                unused_bytes: (fragment_size.get() as usize - chunk.len()) as u32,
+                total_bytes: NonZeroU32::new(chunk.len() as u32).unwrap(),
             })
             .collect();
 


### PR DESCRIPTION
fixes https://github.com/FuelLabs/fuel-block-committer/pull/187#discussion_r2126570434

 The most important changes include updating the logic for calculating `unused_bytes` and `total_bytes` in fragments and adding specific assertions for the last fragment in the test suite.

### Logic updates for fragment size calculations:
* Updated the calculation of `unused_bytes` to reflect the difference between the `fragment_size` and the actual chunk length. Changed `total_bytes` to dynamically use the chunk length instead of the fixed `fragment_size`. (`packages/services/src/block_bundler/eigen_bundler.rs`, [packages/services/src/block_bundler/eigen_bundler.rsL106-R107](diffhunk://#diff-f00075c135b4fe4e11a1030e50b6602a1b48bdf568d49053d27d19a30cd4b551L106-R107))

### Enhancements to test coverage:
* Modified the test suite to include separate assertions for the last fragment, ensuring it handles edge cases where the chunk size may not match the `fragment_size`. (`packages/services/src/block_bundler/eigen_bundler.rs`, [packages/services/src/block_bundler/eigen_bundler.rsL594-R605](diffhunk://#diff-f00075c135b4fe4e11a1030e50b6602a1b48bdf568d49053d27d19a30cd4b551L594-R605))