### PR TITLE
fix: e2e eigen committer uses EIGEN_KEY from env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::024848458133:role/github_oidc_FuelLabs_fuel-block-committer
   AWS_ECR_ORG: fuellabs
   REGISTRY: ghcr.io
+  EIGEN_KEY: ${{ secrets.EIGEN_KEY }}
 
 jobs:
   verify-rust-version:

--- a/e2e/helpers/src/bin/start_committer.rs
+++ b/e2e/helpers/src/bin/start_committer.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
 
     let eth_node = start_eth(false).await?;
     let eth_signers = create_and_fund_kms_signers(&kms, &eth_node).await?;
-    let eigen_key = "".to_string(); // TODO: fill in eigen_key
+    let eigen_key = env!("EIGEN_KEY").to_string();
 
     let request_timeout = Duration::from_secs(5);
     let max_fee = 1_000_000_000_000;


### PR DESCRIPTION
now that we have the `EIGEN_KEY` setup in ci, we can use it in the eigen committer e2e harness
