### PR TITLE
chore(eigen_service): allow checking if the bundle can be submitted

### DIFF
--- a/packages/adapters/eigenda/src/connector.rs
+++ b/packages/adapters/eigenda/src/connector.rs
@@ -125,11 +125,11 @@ where
                 true
             }
             Ok(Err(_)) => {
-                // If we cannot dispatch the fragment due to rate limiting, we should not submit it
+                // Do not perform partial dispatches, if we cannot dispatch the fragment due to rate limiting, we should not submit it
                 false
             }
             Err(_) => {
-                // If the future is not ready, we assume we should not submit it
+                // The fragment is too large to be dispatched, we should not submit it
                 false
             }
         };
@@ -143,11 +143,11 @@ where
                 true
             }
             Ok(Err(_)) => {
-                // If we cannot post the fragment due to rate limiting, we should not submit it
+                // Do not perform partial dispatches, if we cannot post the fragment due to rate limiting, we should not submit it
                 false
             }
             Err(_) => {
-                // If the future is not ready, we assume we should not submit it
+                // No more available slots for posting, we should not submit it
                 false
             }
         };

--- a/packages/services/src/state_committer/eigen_service.rs
+++ b/packages/services/src/state_committer/eigen_service.rs
@@ -146,10 +146,7 @@ where
     }
 
     async fn should_submit(&self, fragment: &BundleFragment) -> Result<bool> {
-        let should_submit = self
-            .da_layer
-            .should_submit_fragment(&fragment.fragment)
-            .await?;
+        let should_submit = self.da_layer.should_submit_fragment(&fragment.fragment);
 
         Ok(should_submit)
     }

--- a/packages/services/src/state_committer/eigen_service.rs
+++ b/packages/services/src/state_committer/eigen_service.rs
@@ -146,10 +146,12 @@ where
     }
 
     async fn should_submit(&self, fragment: &BundleFragment) -> Result<bool> {
-        // TODO check if eigen API is ready to accept more data
-        let _size = fragment.fragment.data.len();
+        let should_submit = self
+            .da_layer
+            .should_submit_fragment(&fragment.fragment)
+            .await?;
 
-        Ok(true)
+        Ok(should_submit)
     }
 
     async fn submit_fragment_if_ready(&self, fragment: BundleFragment) -> Result<()> {

--- a/packages/services/src/state_committer/port.rs
+++ b/packages/services/src/state_committer/port.rs
@@ -66,6 +66,7 @@ pub mod eigen_da {
     #[cfg_attr(feature = "test-helpers", mockall::automock)]
     pub trait Api {
         async fn submit_state_fragment(&self, fragment: Fragment) -> Result<EigenDASubmission>;
+        async fn should_submit_fragment(&self, fragment: &Fragment) -> Result<bool>;
     }
 }
 

--- a/packages/services/src/state_committer/port.rs
+++ b/packages/services/src/state_committer/port.rs
@@ -66,7 +66,7 @@ pub mod eigen_da {
     #[cfg_attr(feature = "test-helpers", mockall::automock)]
     pub trait Api {
         async fn submit_state_fragment(&self, fragment: Fragment) -> Result<EigenDASubmission>;
-        async fn should_submit_fragment(&self, fragment: &Fragment) -> Result<bool>;
+        fn should_submit_fragment(&self, fragment: &Fragment) -> bool;
     }
 }
 


### PR DESCRIPTION
Since our agreement with eigen is purely on the basis of the throughput, we don't need to perform any additional calculations. the condition for submitting a state fragment is purely decided by how much data we have been posting, and by re-using the `RateLimiter` on `EigenDAClient`, we can quickly check if we are exceeding that throughput. 

we also perform an additional check on the call frequency to keep that in check. other than these 2, i cannot think of any other reasons we should throttle blob submission, since we don't have to check for wallet balance or anything else

