### PR TITLE
chore: fix config, add additional params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ dependencies = [
  "config",
  "eigenda",
  "eth",
+ "ethereum-types",
  "fuel",
  "fuel-block-committer-encoding",
  "hex",

--- a/README.md
+++ b/README.md
@@ -324,6 +324,63 @@ The Fuel Block Committer is configured primarily through environment variables.
   - **Allowed Values:** `"disabled"`, `"min"`, or any value up to `"max"` (`"level1"`, `"level2"`, ...)
   - **Example:** `"min"`
 
+#### DA Layer Configuration
+
+- **`COMMITTER__DA_LAYER__TYPE`**
+
+  - **Description:** Specifies the Data Availability layer type to use.
+  - **Allowed Values:** `"EigenDA"`
+  - **Example:** `EigenDA`
+
+- **`COMMITTER__DA_LAYER__KEY`**
+
+  - **Description:** Authentication key for posting requests to the EigenDA disperser.
+  - **Format:** `Private(0x...)` for private keys or `Kms(key-id)` for AWS KMS keys
+  - **Example:** `Kms(arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012)`
+
+- **`COMMITTER__DA_LAYER__DISPERSER_RPC_URL`**
+
+  - **Description:** URL endpoint for the EigenDA disperser RPC service.
+  - **Format:** Valid URL
+  - **Example:** `https://disperser-holesky.eigenda.xyz`
+
+- **`COMMITTER__DA_LAYER__FRAGMENT_SIZE`**
+
+  - **Description:** Size of blob fragments sent to EigenDA. Defaults to 3.5MB if not specified.
+  - **Type:** Positive integer (`NonZeroU32`) in bytes
+  - **Example:** `3670016`
+  - **Note:** Values over 4MB may cause server-side errors during inclusion checks.
+
+- **`COMMITTER__DA_LAYER__FEE_CHECK_INTERVAL`**
+
+  - **Description:** Interval for checking EigenDA fees.
+  - **Format:** Human-readable duration
+  - **Example:** `30s`
+
+- **`COMMITTER__DA_LAYER__POLLING_INTERVAL`**
+
+  - **Description:** Interval for polling EigenDA status. Defaults to 1 second if not specified.
+  - **Format:** Human-readable duration
+  - **Example:** `2s`
+
+- **`COMMITTER__DA_LAYER__API_THROUGHPUT`**
+
+  - **Description:** Allocated API throughput limit in bytes/s for the authenticated address. Defaults to 16 MiB/s if not specified.
+  - **Type:** `u32`
+  - **Example:** `16777216`
+
+- **`COMMITTER__DA_LAYER__ETH_RPC_URL`**
+
+  - **Description:** URL endpoint for the Ethereum RPC service used by EigenDA.
+  - **Format:** Valid URL
+  - **Example:** `https://ethereum-holesky-rpc.publicnode.com`
+
+- **`COMMITTER__DA_LAYER__CERT_VERIFIER_ADDRESS`**
+
+  - **Description:** Address of the certificate verifier contract. Get it from the EigenDA documentation or deployment details.
+  - **Type:** String
+  - **Example:** `0x1234567890123456789012345678901234567890`
+
 ### Configuration Validation
 
 At startup, the committer validates the provided configuration to ensure that:

--- a/committer/Cargo.toml
+++ b/committer/Cargo.toml
@@ -34,6 +34,7 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 url = { workspace = true }
+ethereum-types = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/committer/src/config.rs
+++ b/committer/src/config.rs
@@ -105,7 +105,7 @@ pub struct EigenDaConfig {
     pub key: KeySource,
     /// URL to an EigenDA RPC endpoint.
     #[serde(deserialize_with = "parse_url")]
-    pub rpc: Url,
+    pub disperser_rpc_url: Url,
     /// Blob fragment size.
     /// Defaults to 3.5MB, as 4+MB errors out on the server side when checking for inclusion.
     pub fragment_size: Option<NonZeroU32>,
@@ -115,9 +115,14 @@ pub struct EigenDaConfig {
     /// Polling interval.
     /// Defaults to 1s if not given.
     pub polling_interval: Option<Duration>,
-    /// Allocated API throughput limit in MiB/s (for the address corresponding to the key).
+    /// Allocated API throughput limit in bytes/s (for the address corresponding to the key).
     /// Defaults to 16 MiB/s if not given.
     pub api_throughput: Option<u32>,
+    /// URL to the EigenDA RPC endpoint for Ethereum.
+    #[serde(deserialize_with = "parse_url")]
+    pub eth_rpc_url: Url,
+    /// Certificate verifier address.
+    pub cert_verifier_address: String,
 }
 
 impl EigenDaConfig {

--- a/e2e/tests/tests/eigen_kms.rs
+++ b/e2e/tests/tests/eigen_kms.rs
@@ -2,10 +2,7 @@ use anyhow::Context;
 use anyhow::Result;
 use e2e_helpers::kms::Kms;
 use e2e_helpers::kms::KmsProcess;
-use eigenda::EigenDAClient;
-use eigenda::Throughput;
 use k256::ecdsa::SigningKey as K256SigningKey;
-use rand::RngCore;
 use rand::rngs::OsRng;
 use rust_eigenda_signers::Message;
 use rust_eigenda_signers::PublicKey;
@@ -13,15 +10,8 @@ use rust_eigenda_signers::RecoverableSignature;
 use rust_eigenda_signers::signers::private_key::Signer as PrivateKeySigner;
 use rust_eigenda_v2_client::rust_eigenda_signers::Sign;
 use secp256k1::Secp256k1;
-use services::types::DispersalStatus;
 use sha2::{Digest, Sha256};
-
 use signers::eigen::kms::Signer;
-use std::num::NonZeroU32;
-use std::{env, str::FromStr, time::Duration};
-use tracing::{error, info};
-use tracing_subscriber::EnvFilter;
-use url::Url;
 
 async fn setup_kms_and_signer() -> Result<(KmsProcess, PrivateKeySigner, Signer)> {
     let kms_proc = Kms::default().with_show_logs(false).start().await?;
@@ -103,142 +93,6 @@ async fn test_kms_signer_sign_and_verify() -> Result<()> {
 
     verify_signature_recovery(&rec_sig, &message, &expected_pubkey)
         .context("Signature verification failed")?;
-
-    Ok(())
-}
-
-async fn initialize_tracing() {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .try_init();
-}
-
-#[ignore = "requires EIGEN_KEY environment variable"]
-#[tokio::test]
-async fn test_dispatch_3mb_blob_aws_signer() -> Result<()> {
-    initialize_tracing().await;
-    info!("Starting EigenDA 3MB blob dispatch test with AWS Signer...");
-
-    // 1. Read AWS Secret Name from environment variable
-    let secret_name = env::var("EIGEN_KEY")
-        .context("Failed to read EIGEN_KEY (expected AWS Secret Name) environment variable")?;
-    info!(secret_name = %secret_name, "Using AWS Secret Name from EIGEN_KEY");
-
-    // 2. Initialize AWS Signer
-    let kms_proc = Kms::default().with_show_logs(false).start().await?;
-
-    // Convert hex string to bytes
-    let key_bytes: [u8; 32] = hex::decode(&secret_name).unwrap().try_into().unwrap();
-
-    // Create SecretKey
-    let secret_key = k256::elliptic_curve::SecretKey::from_slice(&key_bytes)?;
-    let k256_signing_key = k256::ecdsa::SigningKey::from(&secret_key);
-
-    let kms_key_id = kms_proc.inject_secp256k1_key(&k256_signing_key).await?;
-
-    let aws_signer = kms_proc.eigen_signer(kms_key_id).await?;
-
-    info!("AwsSigner initialized successfully.");
-
-    // 3. Define RPC URLs and Configuration (using Holesky testnet)
-    let disperser_rpc_url = Url::from_str("https://disperser-holesky.eigenda.xyz")
-        .with_context(|| "Invalid disperser RPC URL")?;
-
-    // Holesky Service Manager Address
-    info!("Configuration prepared. Initializing EigenClient...");
-
-    // 4. Create EigenClient instance
-    let client = EigenDAClient::new(
-        aws_signer,
-        disperser_rpc_url,
-        Throughput {
-            bytes_per_sec: NonZeroU32::new(10_000_000).unwrap(), // 10 MB/s
-            calls_per_sec: NonZeroU32::new(100).unwrap(),        // 100 calls per second
-            max_burst: NonZeroU32::new(1_000_000).unwrap(),      // 1 MB burst
-        },
-    )
-    .await
-    .context("Failed to initialize EigenClient")?;
-
-    info!("EigenClient initialized successfully.");
-
-    // 5. Define 3MB blob data
-    // Max original size = floor(3,145,728 * 31 / 32) = 3,047,424 bytes.
-    const MAX_BLOB_SIZE: usize = 3_047_424;
-    let mut blob_data = vec![0u8; MAX_BLOB_SIZE];
-    OsRng.fill_bytes(&mut blob_data); // Use OsRng for cryptographic randomness
-
-    info!(
-        size = blob_data.len(),
-        "Generated random blob data. Dispatching..."
-    );
-
-    // 6. Dispatch the blob
-    let blob_id = match client.dispatch_blob(blob_data).await {
-        Ok(blob_id) => {
-            info!("---------------------------------------------------");
-            info!("Blob successfully dispatched!");
-            info!(blob_id = %blob_id, "Blob ID received.");
-            info!("---------------------------------------------------");
-            blob_id
-        }
-        Err(e) => {
-            error!("---------------------------------------------------");
-            error!("Failed to dispatch blob: {:?}", e);
-            error!("---------------------------------------------------");
-            return Err(anyhow::anyhow!("Blob dispatch failed: {}", e));
-        }
-    };
-
-    // 7. Poll for inclusion data
-    let polling_timeout = Duration::from_secs(300); // 5 minutes
-    let polling_interval = Duration::from_secs(10); // 10 seconds
-    let start_time = tokio::time::Instant::now();
-
-    info!(
-        timeout = ?polling_timeout,
-        interval = ?polling_interval,
-        "Polling for inclusion data..."
-    );
-
-    loop {
-        if start_time.elapsed() > polling_timeout {
-            error!("Polling timed out after {:?}", polling_timeout);
-            return Err(anyhow::anyhow!(
-                "Polling for inclusion data timed out for blob ID: {}",
-                blob_id
-            ));
-        }
-
-        match client.check_blob_status(&blob_id).await {
-            Ok(blob_status) => {
-                info!("---------------------------------------------------");
-                info!("Inclusion data retrieved successfully!");
-                info!(blob_id = %blob_id);
-                info!(blob_status = ?blob_status, "Inclusion data details.");
-                info!("---------------------------------------------------");
-                // Test passes if blob is successfully finalized
-                if matches!(blob_status, DispersalStatus::Finalized) {
-                    info!("Blob is finalized.");
-                    break;
-                } else {
-                    info!("Blob is not finalized yet, continuing to poll...");
-                }
-            }
-            Err(e) => {
-                error!(blob_id = %blob_id, error = ?e, "Error polling for inclusion data");
-                // Depending on the error, we might want to retry or fail immediately
-                // For now, let's fail on persistent errors during polling
-                return Err(anyhow::anyhow!(
-                    "Error polling for inclusion data for blob ID {}: {}",
-                    blob_id,
-                    e
-                ));
-            }
-        }
-    }
 
     Ok(())
 }

--- a/packages/adapters/eigenda/Cargo.toml
+++ b/packages/adapters/eigenda/Cargo.toml
@@ -34,7 +34,7 @@ humantime = { workspace = true }
 byte-unit = { workspace = true, features = ["byte", "u128"] }
 rust-eigenda-v2-client = { workspace = true }
 rust-eigenda-v2-common = { workspace = true }
-ethereum-types = "0.14.1"
+ethereum-types = { workspace = true }
 async-trait = { workspace = true }
 secp256k1 = { workspace = true }
 anyhow = { workspace = true }

--- a/packages/adapters/eigenda/src/connector.rs
+++ b/packages/adapters/eigenda/src/connector.rs
@@ -1,6 +1,5 @@
 use std::{
     num::NonZeroU32,
-    str::FromStr,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -216,24 +215,26 @@ impl<S> EigenDAClient<S>
 where
     S: Sign + Clone,
 {
-    pub async fn new(signer: S, rpc: Url, throughput: Throughput) -> Result<Self> {
+    pub async fn new(
+        signer: S,
+        rpc: Url,
+        throughput: Throughput,
+        cert_verifier_address: H160,
+        eth_rpc: Url,
+    ) -> Result<Self> {
         // Set up Ethereum RPC URL
         // For now, we're using the same URL for disperser and eth - this may need to be revised
         let disperser_rpc_url = rpc.to_string();
 
         // Set a default Holesky RPC endpoint for Ethereum interaction
         // This could be changed to a configurable parameter
-        let eth_rpc_str = "https://ethereum-holesky-rpc.publicnode.com";
-        let eth_rpc_url = SecretUrl::new(Url::parse(eth_rpc_str).map_err(Error::InvalidRPCUrl)?);
-
-        // TODO: make configurable
-        const CERT_VERIFIER_ADDRESS: &str = "fe52fe1940858dcb6e12153e2104ad0fdfbe1162"; // holesky cert verifier address
+        let eth_rpc_url = SecretUrl::new(eth_rpc);
 
         let config = PayloadDisperserConfig {
             polynomial_form: PayloadForm::Coeff,
             blob_version: 0,
-            cert_verifier_address: H160::from_str(CERT_VERIFIER_ADDRESS).expect("qed"),
-            eth_rpc_url: eth_rpc_url.clone(),
+            cert_verifier_address,
+            eth_rpc_url,
             disperser_rpc: disperser_rpc_url,
             use_secure_grpc_flag: true,
         };


### PR DESCRIPTION
updates the readme with the new config params. fixes the throughput config since we expect bytes/sec. made cert verifier configurable, along with the eth rpc url. this is separate from the committer_eth_rpc because eigen v2 is on holesky.

removed the test in `eigen_kms.rs` which duplicates the test that already exists in `eigen_state.rs`. it performs the same checks
